### PR TITLE
Add ESET Protect On-Prem syslog integration for Wazuh

### DIFF
--- a/README_syslog.md
+++ b/README_syslog.md
@@ -1,0 +1,93 @@
+# ESET Protect On-Prem Syslog Integration for Wazuh
+
+This directory contains Wazuh decoders and rules for ingesting ESET Protect On-Premise syslog JSON output.
+
+## Background
+
+The existing `eset_local_rules.xml` is designed for the ESET Cloud API integration script, which wraps events in a custom JSON structure with fields like `eset.category`, `eset.severityLevel`, and `eset.edrRuleUuid`.
+
+ESET Protect On-Premise has a built-in Syslog export feature that sends events directly over syslog in RFC 5424 format with a JSON payload. The JSON schema differs from the API output — it uses root-level fields like `event_type`, `severity`, `threat_name`, etc. as documented at:
+https://help.eset.com/protect_admin/12.1/en-US/events-exported-to-json-format.html
+
+This integration provides native Wazuh support for these syslog events.
+
+## Files
+
+| File | Wazuh Location | Description |
+|------|---------------|-------------|
+| `eset_syslog_decoder.xml` | `/var/ossec/etc/decoders/local_decoder.xml` | Custom decoder to handle RFC 5424 syslog with UTF-8 BOM |
+| `eset_syslog_rules.xml` | `/var/ossec/etc/rules/eset_syslog_rules.xml` | 1,263 rules covering all ESET event types with MITRE ATT&CK mappings |
+
+## Supported Event Types
+
+| Event Type | Rule ID | Description |
+|-----------|---------|-------------|
+| `Threat_Event` | 440020 | Antivirus detections |
+| `FirewallAggregated_Event` | 440030 | Firewall detections |
+| `HipsAggregated_Event` | 440040 | HIPS detections |
+| `EnterpriseInspectorAlert_Event` | 440050 | ESET Inspect / EDR alerts |
+| `BlockedFiles_Event` | 440055 | Blocked files |
+| `Audit_Event` | 440060 | Console audit log |
+| `FilteredWebsites_Event` | 440080 | Web protection detections |
+
+## Severity Escalation
+
+| Severity | Rule ID | Wazuh Level |
+|----------|---------|-------------|
+| Information / Notice | (category rule) | 3 |
+| Warning | 440120 | 7 |
+| Error | 440121 | 7 |
+| Critical | 440130 | 12 |
+| Fatal | 440131 | 15 |
+
+## EDR / ESET Inspect Rules
+
+All 1,247 EDR rules from `eset_local_rules.xml` have been mapped to match the `rulename` field in `EnterpriseInspectorAlert_Event` syslog output. Original rule IDs (420140-432600), severity levels, and MITRE ATT&CK technique IDs are preserved.
+
+## ESET Protect On-Prem Configuration
+
+1. Navigate to **More > Settings > Advanced Settings > Syslog server**
+2. Enable **Use Syslog server**
+3. Enter your Wazuh Manager IP and port (e.g., 514)
+4. Set **Exported logs format** to **JSON**
+5. Select the log categories you want to export
+
+## Wazuh Configuration
+
+### 1. Decoder
+
+Append the contents of `eset_syslog_decoder.xml` to `/var/ossec/etc/decoders/local_decoder.xml`, or place it as a separate file in `/var/ossec/etc/decoders/`.
+
+The decoder handles two challenges:
+- ESET sends RFC 5424 syslog, but Wazuh expects RFC 3164 — so `program_name` is not extracted correctly by the default pre-decoder
+
+### 2. Rules
+
+Copy `eset_syslog_rules.xml` to `/var/ossec/etc/rules/`.
+
+### 3. Syslog Listener
+
+Add a syslog listener to `/var/ossec/etc/ossec.conf`:
+
+```xml
+<remote>
+  <connection>syslog</connection>
+  <port>514</port>
+  <protocol>tcp</protocol>
+  <allowed-ips>YOUR_ESET_SERVER_IP</allowed-ips>
+</remote>
+```
+
+### 4. Restart
+
+Restart the Wazuh Manager to apply changes.
+
+## Verification
+
+Use `wazuh-logtest` or the Wazuh UI Ruleset Test tool to verify. Paste a raw ESET syslog message (including the RFC 5424 header):
+
+```
+<14>1 2026-02-27T16:25:37.704Z YOURHOST ERAServer 3432 - - {"event_type":"Threat_Event","ipv4":"192.168.1.100","hostname":"workstation01","severity":"Warning","threat_name":"Eicar","action_taken":"Connection terminated","threat_handled":true}
+```
+
+Phase 3 should show the matching rule firing.

--- a/eset_syslog_decoder.xml
+++ b/eset_syslog_decoder.xml
@@ -1,0 +1,19 @@
+<!--
+  Custom Decoder for ESET Protect On-Premise Syslog (JSON format)
+  
+  ESET Protect On-Prem sends RFC 5424 syslog with JSON payload.
+  Wazuh expects RFC 3164, so the standard pre-decoder cannot extract program_name correctly.
+  This decoder uses pcre2 regex to match the ERAServer program name and extract the JSON
+  payload using the built-in JSON_Decoder plugin.
+
+  Installation: /var/ossec/etc/decoders/local_decoder.xml
+-->
+<decoder name="eset-protect-syslog">
+  <prematch type="pcre2">ERAServer</prematch>
+</decoder>
+
+<decoder name="eset-protect-syslog-json">
+  <parent>eset-protect-syslog</parent>
+  <prematch type="pcre2">ERAServer[^{]+</prematch>
+  <plugin_decoder offset="after_prematch">JSON_Decoder</plugin_decoder>
+</decoder>

--- a/eset_syslog_rules.xml
+++ b/eset_syslog_rules.xml
@@ -1,0 +1,12381 @@
+<group name="eset,">
+
+  <rule id="440010" level="0">
+    <decoded_as>eset-protect-syslog</decoded_as>
+    <description>ESET Protect base rule.</description>
+  </rule>
+
+  <rule id="440020" level="3">
+    <if_sid>440010</if_sid>
+    <field name="event_type">Threat_Event</field>
+    <description>ESET: Threat event - $(threat_name) on $(hostname).</description>
+    <group>threat_event,</group>
+  </rule>
+
+  <rule id="440030" level="3">
+    <if_sid>440010</if_sid>
+    <field name="event_type">FirewallAggregated_Event</field>
+    <description>ESET: Firewall event on $(hostname).</description>
+    <group>firewall,</group>
+  </rule>
+
+  <rule id="440040" level="3">
+    <if_sid>440010</if_sid>
+    <field name="event_type">HipsAggregated_Event</field>
+    <description>ESET: HIPS event on $(hostname).</description>
+  </rule>
+
+  <rule id="440050" level="3">
+    <if_sid>440010</if_sid>
+    <field name="event_type">EnterpriseInspectorAlert_Event</field>
+    <description>ESET: EDR alert - $(rulename) on $(hostname).</description>
+  </rule>
+
+  <rule id="440055" level="3">
+    <if_sid>440010</if_sid>
+    <field name="event_type">BlockedFiles_Event</field>
+    <description>ESET: Blocked file on $(hostname).</description>
+  </rule>
+
+  <rule id="440060" level="3">
+    <if_sid>440010</if_sid>
+    <field name="event_type">Audit_Event</field>
+    <description>ESET: Audit event - $(user) $(action) $(domain).</description>
+    <group>audit_anom,</group>
+  </rule>
+
+  <rule id="440080" level="3">
+    <if_sid>440010</if_sid>
+    <field name="event_type">FilteredWebsites_Event</field>
+    <description>ESET: Web access event on $(hostname).</description>
+    <group>web,</group>
+  </rule>
+
+  <rule id="440120" level="7">
+    <if_sid>440020,440030,440040,440050,440055,440060,440080</if_sid>
+    <field name="severity">Warning</field>
+    <description>ESET: Warning severity event - $(threat_name) on $(hostname).</description>
+    <group>gdpr_IV_35.7.d,gpg13_4.12,hipaa_164.312.a.1,nist_800_53_SC.7,pci_dss_1.4,tsc_CC6.7,tsc_CC6.8,</group>
+  </rule>
+
+  <rule id="440121" level="7">
+    <if_sid>440020,440030,440040,440050,440055,440060,440080</if_sid>
+    <field name="severity">Error</field>
+    <description>ESET: Error severity event - $(threat_name) on $(hostname).</description>
+    <group>gdpr_IV_35.7.d,gpg13_4.12,hipaa_164.312.a.1,nist_800_53_SC.7,pci_dss_1.4,tsc_CC6.7,tsc_CC6.8,</group>
+  </rule>
+
+  <rule id="440130" level="12">
+    <if_sid>440020,440030,440040,440050,440055,440060,440080</if_sid>
+    <field name="severity">Critical</field>
+    <description>ESET: Critical severity event - $(threat_name) on $(hostname).</description>
+    <group>gdpr_IV_35.7.d,gpg13_4.12,hipaa_164.312.a.1,nist_800_53_SC.7,pci_dss_1.4,tsc_CC6.7,tsc_CC6.8,</group>
+  </rule>
+
+  <rule id="440131" level="15">
+    <if_sid>440020,440030,440040,440050,440055,440060,440080</if_sid>
+    <field name="severity">Fatal</field>
+    <description>ESET: Fatal severity event - $(threat_name) on $(hostname).</description>
+    <group>gdpr_IV_35.7.d,gpg13_4.12,hipaa_164.312.a.1,nist_800_53_SC.7,pci_dss_1.4,tsc_CC6.7,tsc_CC6.8,</group>
+  </rule>
+
+  <rule id="440140" level="10">
+    <if_sid>440020</if_sid>
+    <field name="action_taken">Connection terminated</field>
+    <description>ESET: Threat $(threat_name) - connection terminated on $(hostname).</description>
+    <group>threat_event,</group>
+  </rule>
+
+  <rule id="440141" level="10">
+    <if_sid>440020</if_sid>
+    <field name="action_taken">Blocked</field>
+    <description>ESET: Threat $(threat_name) was blocked on $(hostname).</description>
+    <group>threat_event,</group>
+  </rule>
+
+  <rule id="440142" level="10">
+    <if_sid>440020</if_sid>
+    <field name="action_taken">Deleted</field>
+    <description>ESET: Threat $(threat_name) was deleted on $(hostname).</description>
+    <group>threat_event,</group>
+  </rule>
+
+  <rule id="440143" level="10">
+    <if_sid>440020</if_sid>
+    <field name="action_taken">Quarantined</field>
+    <description>ESET: Threat $(threat_name) was quarantined on $(hostname).</description>
+    <group>threat_event,</group>
+  </rule>
+
+  <rule id="440144" level="10">
+    <if_sid>440020</if_sid>
+    <field name="action_taken">Cleaned</field>
+    <description>ESET: Threat $(threat_name) was cleaned on $(hostname).</description>
+    <group>threat_event,</group>
+  </rule>
+
+  <rule id="440145" level="12">
+    <if_sid>440020</if_sid>
+    <field name="threat_handled">false</field>
+    <description>ESET: UNHANDLED threat $(threat_name) on $(hostname)!</description>
+    <group>threat_event,</group>
+  </rule>
+
+  <rule id="420140" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Active Setup autostart registry modified by an unpopular process [A0100].</description>
+    <field name="rulename" type="osmatch">Active Setup autostart registry modified by an unpopular process [A0100]</field>
+    <mitre>
+      <id>T1547.014</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420150" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: AppInit_Dlls registry was modified [A0101a].</description>
+    <field name="rulename" type="osmatch">AppInit_Dlls registry was modified [A0101a]</field>
+    <mitre>
+      <id>T1546.010</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420160" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: AppCertDLLs registry was modified [A0101b].</description>
+    <field name="rulename" type="osmatch">AppCertDLLs registry was modified [A0101b]</field>
+    <mitre>
+      <id>T1546.009</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420170" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Legacy AutoStart registry was modified [A0102].</description>
+    <field name="rulename" type="osmatch">Legacy AutoStart registry was modified [A0102]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420180" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Common AutoStart registry modified by an unpopular process [A0103a].</description>
+    <field name="rulename" type="osmatch">Common AutoStart registry modified by an unpopular process [A0103a]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420190" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Common AutoStart registry modified by reg.exe [A0103b].</description>
+    <field name="rulename" type="osmatch">Common AutoStart registry modified by reg.exe [A0103b]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420200" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Common AutoStart registry modified by PowerShell [A0103c].</description>
+    <field name="rulename" type="osmatch">Common AutoStart registry modified by PowerShell [A0103c]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1059.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420210" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Common AutoStart registry modified by script interpreter [A0103d].</description>
+    <field name="rulename" type="osmatch">Common AutoStart registry modified by script interpreter [A0103d]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1059.007</id>
+      <id>T1218.005</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420220" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Session Manager AutoStart registry modified by unpopular process [A0104a].</description>
+    <field name="rulename" type="osmatch">Session Manager AutoStart registry modified by unpopular process [A0104a]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420230" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Session Manager AutoStart registry modified by reg.exe [A0104b].</description>
+    <field name="rulename" type="osmatch">Session Manager AutoStart registry modified by reg.exe [A0104b]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420240" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Session Manager AutoStart registry modified by PowerShell [A0104c].</description>
+    <field name="rulename" type="osmatch">Session Manager AutoStart registry modified by PowerShell [A0104c]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1059.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420250" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Session Manager AutoStart registry modified by script interpreter [A0104d].</description>
+    <field name="rulename" type="osmatch">Session Manager AutoStart registry modified by script interpreter [A0104d]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1059.007</id>
+      <id>T1218.005</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420260" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Credential Providers registry modified by an unpopular process [A0105a].</description>
+    <field name="rulename" type="osmatch">Credential Providers registry modified by an unpopular process [A0105a]</field>
+    <mitre>
+      <id>T1547</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420270" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Credential Providers registry modified by reg.exe [A0105b].</description>
+    <field name="rulename" type="osmatch">Credential Providers registry modified by reg.exe [A0105b]</field>
+    <mitre>
+      <id>T1547</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420280" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Credential Providers registry modified by PowerShell [A0105c].</description>
+    <field name="rulename" type="osmatch">Credential Providers registry modified by PowerShell [A0105c]</field>
+    <mitre>
+      <id>T1547</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420290" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Credential Providers registry modified by by script interpreter [A0105d].</description>
+    <field name="rulename" type="osmatch">Credential Providers registry modified by by script interpreter [A0105d]</field>
+    <mitre>
+      <id>T1547</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420300" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Default Windows .NET debugger registry modified [A0106].</description>
+    <field name="rulename" type="osmatch">Default Windows .NET debugger registry modified [A0106]</field>
+    <mitre>
+      <id>T1546</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420310" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Default Windows script debugger registry modified [A0107].</description>
+    <field name="rulename" type="osmatch">Default Windows script debugger registry modified [A0107]</field>
+    <mitre>
+      <id>T1546</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420320" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Default Windows debugger registry modified [A0108].</description>
+    <field name="rulename" type="osmatch">Default Windows debugger registry modified [A0108]</field>
+    <mitre>
+      <id>T1546</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420330" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: .NET profiler registry modified [A0109a].</description>
+    <field name="rulename" type="osmatch">.NET profiler registry modified [A0109a]</field>
+    <mitre>
+      <id>T1574.012</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420340" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC bypass - .NET profiler registry [A0109b].</description>
+    <field name="rulename" type="osmatch">Possible UAC bypass - .NET profiler registry [A0109b]</field>
+    <mitre>
+      <id>T1574.012</id>
+      <id>T1548.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420350" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: .NET winappxrt.dll file modified [A0110].</description>
+    <field name="rulename" type="osmatch">.NET winappxrt.dll file modified [A0110]</field>
+    <mitre>
+      <id>T1574.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="420360" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: .NET appx_process was enabled [A0111].</description>
+    <field name="rulename" type="osmatch">.NET appx_process was enabled [A0111]</field>
+    <mitre>
+      <id>T1574.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420370" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Browser Helper Objects registry modified by an unpopular process [A0112].</description>
+    <field name="rulename" type="osmatch">Browser Helper Objects registry modified by an unpopular process [A0112]</field>
+    <mitre>
+      <id>T1176</id>
+      <id>T1185</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420380" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: ShellIconOverlayIdentifiers registry modified by unpopular process [A0113].</description>
+    <field name="rulename" type="osmatch">ShellIconOverlayIdentifiers registry modified by unpopular process [A0113]</field>
+    <mitre>
+      <id>T1546.015</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420390" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Explorer ShellServiceObjects registry entry was modified [A0114].</description>
+    <field name="rulename" type="osmatch">Windows Explorer ShellServiceObjects registry entry was modified [A0114]</field>
+    <mitre>
+      <id>T1546.015</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420400" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: IconServiceLib registry was modified [A0116].</description>
+    <field name="rulename" type="osmatch">IconServiceLib registry was modified [A0116]</field>
+    <mitre>
+      <id>T1574</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420410" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell profile file for all users on all hosts was modified [A0117].</description>
+    <field name="rulename" type="osmatch">PowerShell profile file for all users on all hosts was modified [A0117]</field>
+    <mitre>
+      <id>T1546.013</id>
+    </mitre>
+  </rule>
+
+  <rule id="420420" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell profile file for all users on the current host was modified [A0118].</description>
+    <field name="rulename" type="osmatch">PowerShell profile file for all users on the current host was modified [A0118]</field>
+    <mitre>
+      <id>T1546.013</id>
+    </mitre>
+  </rule>
+
+  <rule id="420430" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell profile for the current user on all hosts was modified [A0119].</description>
+    <field name="rulename" type="osmatch">PowerShell profile for the current user on all hosts was modified [A0119]</field>
+    <mitre>
+      <id>T1546.013</id>
+    </mitre>
+  </rule>
+
+  <rule id="420440" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell profile file for the current user on the current host was modified [A0120].</description>
+    <field name="rulename" type="osmatch">PowerShell profile file for the current user on the current host was modified [A0120]</field>
+    <mitre>
+      <id>T1546.013</id>
+    </mitre>
+  </rule>
+
+  <rule id="420450" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Rover.dll registry was modified [A0121].</description>
+    <field name="rulename" type="osmatch">Rover.dll registry was modified [A0121]</field>
+    <mitre>
+      <id>T1574</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420460" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Rover.dll file modified [A0122].</description>
+    <field name="rulename" type="osmatch">Rover.dll file modified [A0122]</field>
+    <mitre>
+      <id>T1574</id>
+    </mitre>
+  </rule>
+
+  <rule id="420470" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: RunServices AutoStart registry was modified [A0123].</description>
+    <field name="rulename" type="osmatch">RunServices AutoStart registry was modified [A0123]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420480" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: SafeBoot AlternateShell registry was modified [A0124].</description>
+    <field name="rulename" type="osmatch">SafeBoot AlternateShell registry was modified [A0124]</field>
+    <mitre>
+      <id>T1546</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420490" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: SecurityProviders registry was modified [A0125].</description>
+    <field name="rulename" type="osmatch">SecurityProviders registry was modified [A0125]</field>
+    <mitre>
+      <id>T1547.005</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420500" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: ServiceControlManagerExtension registry was modified [A0126].</description>
+    <field name="rulename" type="osmatch">ServiceControlManagerExtension registry was modified [A0126]</field>
+    <mitre>
+      <id>T1574</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420510" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File modified in %startup% folder by suspicious process [A0127a].</description>
+    <field name="rulename" type="osmatch">File modified in %startup% folder by suspicious process [A0127a]</field>
+    <mitre>
+      <id>T1547.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="420520" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious executable created in %startup% folder [A0127b].</description>
+    <field name="rulename" type="osmatch">Suspicious executable created in %startup% folder [A0127b]</field>
+    <mitre>
+      <id>T1547.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="420530" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Terminal Server autostart registry was modified [A0128].</description>
+    <field name="rulename" type="osmatch">Terminal Server autostart registry was modified [A0128]</field>
+    <mitre>
+      <id>T1546</id>
+      <id>T1021.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420540" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: MPR (Multiple Provider Router) registry was modified [A0129].</description>
+    <field name="rulename" type="osmatch">MPR (Multiple Provider Router) registry was modified [A0129]</field>
+    <mitre>
+      <id>T1037.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420550" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Visual Basic monitor dll registry modified [A0130].</description>
+    <field name="rulename" type="osmatch">Visual Basic monitor dll registry modified [A0130]</field>
+    <mitre>
+      <id>T1574</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420560" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows CE AutoStart registry was modified [A0131].</description>
+    <field name="rulename" type="osmatch">Windows CE AutoStart registry was modified [A0131]</field>
+    <mitre>
+      <id>T1546</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420570" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows NT Drivers32 registry modified by unpopular process [A0132].</description>
+    <field name="rulename" type="osmatch">Windows NT Drivers32 registry modified by unpopular process [A0132]</field>
+    <mitre>
+      <id>T1574</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420580" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows NT Font Drivers registry was modified [A0133].</description>
+    <field name="rulename" type="osmatch">Windows NT Font Drivers registry was modified [A0133]</field>
+    <mitre>
+      <id>T1547</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420590" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Winlogon autostart registry was modified by unpopular process [A0134a].</description>
+    <field name="rulename" type="osmatch">Winlogon autostart registry was modified by unpopular process [A0134a]</field>
+    <mitre>
+      <id>T1547.004</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420600" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Winlogon autostart registry was modified by reg.exe [A0134b].</description>
+    <field name="rulename" type="osmatch">Winlogon autostart registry was modified by reg.exe [A0134b]</field>
+    <mitre>
+      <id>T1547.004</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420610" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Winlogon autostart registry was modified by PowerShell [A0134c].</description>
+    <field name="rulename" type="osmatch">Winlogon autostart registry was modified by PowerShell [A0134c]</field>
+    <mitre>
+      <id>T1547.004</id>
+      <id>T1059.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420620" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Winlogon autostart registry was modified by script interpreter [A0134d].</description>
+    <field name="rulename" type="osmatch">Winlogon autostart registry was modified by script interpreter [A0134d]</field>
+    <mitre>
+      <id>T1547.004</id>
+      <id>T1059.007</id>
+      <id>T1218.005</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420630" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WinRAR ExternalViewer registry modified [A0135].</description>
+    <field name="rulename" type="osmatch">WinRAR ExternalViewer registry modified [A0135]</field>
+    <mitre>
+      <id>T1546</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420640" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Winsock2 AutoDial registry modified [A0136].</description>
+    <field name="rulename" type="osmatch">Winsock2 AutoDial registry modified [A0136]</field>
+    <mitre>
+      <id>T1546</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420650" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WinZip external programs registry modified [A0137].</description>
+    <field name="rulename" type="osmatch">WinZip external programs registry modified [A0137]</field>
+    <mitre>
+      <id>T1546</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420660" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Legacy Scheduled task file written or modified [A0138].</description>
+    <field name="rulename" type="osmatch">Legacy Scheduled task file written or modified [A0138]</field>
+    <mitre>
+      <id>T1053.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="420670" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule:  Custom application compatibility shim file was created/modified [A0139a].</description>
+    <field name="rulename" type="osmatch">Custom application compatibility shim file was created/modified [A0139a]</field>
+    <mitre>
+      <id>T1546.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="420680" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule:  Default Application Compatibility Database file was modified [A0139b].</description>
+    <field name="rulename" type="osmatch">Default Application Compatibility Database file was modified [A0139b]</field>
+    <mitre>
+      <id>T1546.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="420690" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule:  Custom application compatibility shim registry was modified [A0140].</description>
+    <field name="rulename" type="osmatch">Custom application compatibility shim registry was modified [A0140]</field>
+    <mitre>
+      <id>T1546.011</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420700" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File association for execution changed by an unpopular process [A0141] .</description>
+    <field name="rulename" type="osmatch">File association for execution changed by an unpopular process [A0141]</field>
+    <mitre>
+      <id>T1546.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420710" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Exchange Transport Agent configuration file changed [A0142].</description>
+    <field name="rulename" type="osmatch">Microsoft Exchange Transport Agent configuration file changed [A0142]</field>
+    <mitre>
+      <id>T1505.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="420720" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell with command line Microsoft Exchange Transport Agent install [A0143].</description>
+    <field name="rulename" type="osmatch">PowerShell with command line Microsoft Exchange Transport Agent install [A0143]</field>
+    <mitre>
+      <id>T1505.002</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="420730" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Management Instrumentation event subscription [A0144].</description>
+    <field name="rulename" type="osmatch">Windows Management Instrumentation event subscription [A0144]</field>
+    <mitre>
+      <id>T1546.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="420740" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Image File Execution Options Debugger registry was modified [A0145].</description>
+    <field name="rulename" type="osmatch">Image File Execution Options Debugger registry was modified [A0145]</field>
+    <mitre>
+      <id>T1546.012</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420750" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Print processor registry was modified by suspicious process [A0146].</description>
+    <field name="rulename" type="osmatch">Print processor registry was modified by suspicious process [A0146]</field>
+    <mitre>
+      <id>T1547.012</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420760" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Scheduled Task via PS_ScheduledTask class [A0147].</description>
+    <field name="rulename" type="osmatch">Scheduled Task via PS_ScheduledTask class [A0147]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="420770" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell 7 profile was modified [A0148].</description>
+    <field name="rulename" type="osmatch">PowerShell 7 profile was modified [A0148]</field>
+    <mitre>
+      <id>T1546.013</id>
+    </mitre>
+  </rule>
+
+  <rule id="420780" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process creation command line audit disabled [A0200].</description>
+    <field name="rulename" type="osmatch">Process creation command line audit disabled [A0200]</field>
+    <mitre>
+      <id>T1562.002</id>
+      <id>T1562.003</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420790" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Registry Tools (regedit.exe) were disabled [A0201a].</description>
+    <field name="rulename" type="osmatch">Registry Tools (regedit.exe) were disabled [A0201a]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420800" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Registry Tools (regedit.exe) were enabled [A0201b].</description>
+    <field name="rulename" type="osmatch">Registry Tools (regedit.exe) were enabled [A0201b]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420810" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Hosts file location registry was modified [A0202].</description>
+    <field name="rulename" type="osmatch">Hosts file location registry was modified [A0202]</field>
+    <mitre>
+      <id>T1036</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420820" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: LSA registry entry was modified by an unpopular process [A0204].</description>
+    <field name="rulename" type="osmatch">LSA registry entry was modified by an unpopular process [A0204]</field>
+    <mitre>
+      <id>T1547.008</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420830" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell module logging disabled [A0206].</description>
+    <field name="rulename" type="osmatch">PowerShell module logging disabled [A0206]</field>
+    <mitre>
+      <id>T1562.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420840" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell registry shell path modified [A0208].</description>
+    <field name="rulename" type="osmatch">PowerShell registry shell path modified [A0208]</field>
+    <mitre>
+      <id>T1562.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420850" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell transcription disabled [A0209].</description>
+    <field name="rulename" type="osmatch">PowerShell transcription disabled [A0209]</field>
+    <mitre>
+      <id>T1562.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420860" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Security Options: Clear pagefile on shutdown enabled [A0211a].</description>
+    <field name="rulename" type="osmatch">Security Options: Clear pagefile on shutdown enabled [A0211a]</field>
+    <mitre>
+      <id>T1562.006</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420870" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Security Options: Clear pagefile on shutdown disabled [A0211b].</description>
+    <field name="rulename" type="osmatch">Security Options: Clear pagefile on shutdown disabled [A0211b]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420880" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Security Options: User Account Control - Prompt for credentials enabled for users [A0212a].</description>
+    <field name="rulename" type="osmatch">Security Options: User Account Control - Prompt for credentials enabled for users [A0212a]</field>
+    <mitre>
+      <id>T1112</id>
+      <id>T1562</id>
+    </mitre>
+  </rule>
+
+  <rule id="420890" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Security Options: User Account Control - Prompt for consent enabled for administrators [A0212c].</description>
+    <field name="rulename" type="osmatch">Security Options: User Account Control - Prompt for consent enabled for administrators [A0212c]</field>
+    <mitre>
+      <id>T1112</id>
+      <id>T1562</id>
+    </mitre>
+  </rule>
+
+  <rule id="420900" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Security Options: Interactive Login Message for users modified [A0215].</description>
+    <field name="rulename" type="osmatch">Security Options: Interactive Login Message for users modified [A0215]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420910" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Security Options: Recovery Console settings modified [A0216].</description>
+    <field name="rulename" type="osmatch">Security Options: Recovery Console settings modified [A0216]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420920" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PromptOnSecureDesktop modified by unpopular process [A0218].</description>
+    <field name="rulename" type="osmatch">PromptOnSecureDesktop modified by unpopular process [A0218]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420930" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Startup folder location registry modified by unpopular process [A0219a].</description>
+    <field name="rulename" type="osmatch">Startup folder location registry modified by unpopular process [A0219a]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420940" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Startup folder location registry modified by reg.exe [A0219b].</description>
+    <field name="rulename" type="osmatch">Startup folder location registry modified by reg.exe [A0219b]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420950" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Startup folder location registry modified by PowerShell [A0219c].</description>
+    <field name="rulename" type="osmatch">Startup folder location registry modified by PowerShell [A0219c]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="420960" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Startup folder location registry modified by script interpreter [A0219d].</description>
+    <field name="rulename" type="osmatch">Startup folder location registry modified by script interpreter [A0219d]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+      <id>T1059.007</id>
+      <id>T1218.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="420970" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Firewall exceptions allowed [A0220].</description>
+    <field name="rulename" type="osmatch">Windows Firewall exceptions allowed [A0220]</field>
+    <mitre>
+      <id>T1562.004</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420980" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Explorer shows hidden disabled files [A0221].</description>
+    <field name="rulename" type="osmatch">Windows Explorer shows hidden disabled files [A0221]</field>
+    <mitre>
+      <id>T1564.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="420990" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Explorer hide extensions for known file types enabled [A0222].</description>
+    <field name="rulename" type="osmatch">Windows Explorer hide extensions for known file types enabled [A0222]</field>
+    <mitre>
+      <id>T1564.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="421000" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Firewall disabled [A0223].</description>
+    <field name="rulename" type="osmatch">Windows Firewall disabled [A0223]</field>
+    <mitre>
+      <id>T1562.004</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="421010" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Internet Explorer settings modified [A0224].</description>
+    <field name="rulename" type="osmatch">Internet Explorer settings modified [A0224]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="421020" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC bypass - registry shell associations [A0225].</description>
+    <field name="rulename" type="osmatch">Possible UAC bypass - registry shell associations [A0225]</field>
+    <mitre>
+      <id>T1548.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="421030" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC bypass - windir path changed [A0226].</description>
+    <field name="rulename" type="osmatch">Possible UAC bypass - windir path changed [A0226]</field>
+    <mitre>
+      <id>T1548.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="421040" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Command Prompt Was Disabled [A0227].</description>
+    <field name="rulename" type="osmatch">Command Prompt Was Disabled [A0227]</field>
+    <mitre>
+      <id>T1112</id>
+      <id>T1562.001</id>
+      <id>T1059.001</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="421050" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Safe mode boot service modified [A0228].</description>
+    <field name="rulename" type="osmatch">Safe mode boot service modified [A0228]</field>
+    <mitre>
+      <id>T1562.009</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="421060" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WDigest Clear-Text Passwords Enabled [A0229].</description>
+    <field name="rulename" type="osmatch">WDigest Clear-Text Passwords Enabled [A0229]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="421070" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Driver Signing policy compromised [A0230].</description>
+    <field name="rulename" type="osmatch">Driver Signing policy compromised [A0230]</field>
+    <mitre>
+      <id>T1112</id>
+      <id>T1553.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="421080" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: ADS written by unpopular process [A0300] .</description>
+    <field name="rulename" type="osmatch">ADS written by unpopular process [A0300]</field>
+    <mitre>
+      <id>T1564.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="421090" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Autorun.inf file was created/modified [A0301].</description>
+    <field name="rulename" type="osmatch">Autorun.inf file was created/modified [A0301]</field>
+    <mitre>
+      <id>T1091</id>
+    </mitre>
+  </rule>
+
+  <rule id="421100" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Zone.Identifier deleted by an unpopular process [A0302].</description>
+    <field name="rulename" type="osmatch">Zone.Identifier deleted by an unpopular process [A0302]</field>
+    <mitre>
+      <id>T1564.004</id>
+      <id>T1070.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="421110" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Autorun.inf file was deleted [A0303].</description>
+    <field name="rulename" type="osmatch">Autorun.inf file was deleted [A0303]</field>
+    <mitre>
+      <id>T1091</id>
+      <id>T1070.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="421120" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Accessibility Features file modified [A0304].</description>
+    <field name="rulename" type="osmatch">Accessibility Features file modified [A0304]</field>
+    <mitre>
+      <id>T1546.008</id>
+    </mitre>
+  </rule>
+
+  <rule id="421130" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: HTA file written/renamed [A0305].</description>
+    <field name="rulename" type="osmatch">HTA file written/renamed [A0305]</field>
+    <mitre>
+      <id>T1218.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="421140" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell has dropped a suspicious executable [A0306].</description>
+    <field name="rulename" type="osmatch">PowerShell has dropped a suspicious executable [A0306]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421150" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Script Host has dropped a suspicious executable [A0307].</description>
+    <field name="rulename" type="osmatch">Windows Script Host has dropped a suspicious executable [A0307]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421160" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office application has dropped a suspicious executable [A0308].</description>
+    <field name="rulename" type="osmatch">Microsoft Office application has dropped a suspicious executable [A0308]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421170" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PDF reader application has dropped a suspicious executable [A0309].</description>
+    <field name="rulename" type="osmatch">PDF reader application has dropped a suspicious executable [A0309]</field>
+    <mitre>
+      <id>T1203</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421180" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Rundll32 has dropped a suspicious executable [A0310].</description>
+    <field name="rulename" type="osmatch">Rundll32 has dropped a suspicious executable [A0310]</field>
+    <mitre>
+      <id>T1218.011</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421190" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Regsvr32 has dropped a suspicious executable [A0311].</description>
+    <field name="rulename" type="osmatch">Regsvr32 has dropped a suspicious executable [A0311]</field>
+    <mitre>
+      <id>T1218.010</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421200" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Mshta.exe has dropped a suspicious executable [A0312].</description>
+    <field name="rulename" type="osmatch">Mshta.exe has dropped a suspicious executable [A0312]</field>
+    <mitre>
+      <id>T1218.005</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421210" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Certutil has dropped a suspicious executable [A0313].</description>
+    <field name="rulename" type="osmatch">Certutil has dropped a suspicious executable [A0313]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1140</id>
+    </mitre>
+  </rule>
+
+  <rule id="421220" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Net utility executed with redirected output [A0314].</description>
+    <field name="rulename" type="osmatch">Net utility executed with redirected output [A0314]</field>
+    <mitre>
+      <id>T1087.001</id>
+      <id>T1087.002</id>
+      <id>T1136.001</id>
+      <id>T1136.002</id>
+      <id>T1070.005</id>
+      <id>T1135</id>
+      <id>T1201</id>
+      <id>T1069.001</id>
+      <id>T1069.002</id>
+      <id>T1021.002</id>
+      <id>T1018</id>
+      <id>T1049</id>
+      <id>T1007</id>
+      <id>T1569.002</id>
+      <id>T1124</id>
+    </mitre>
+  </rule>
+
+  <rule id="421230" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Script interpreter saved non-default script file [A0316].</description>
+    <field name="rulename" type="osmatch">Script interpreter saved non-default script file [A0316]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="421240" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Scp.exe has dropped an executable [A0318].</description>
+    <field name="rulename" type="osmatch">Scp.exe has dropped an executable [A0318]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="421250" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious DLL Dropped in Windows Print Spool Folder [A0319].</description>
+    <field name="rulename" type="osmatch">Suspicious DLL Dropped in Windows Print Spool Folder [A0319]</field>
+    <mitre>
+      <id>T1068</id>
+      <id>T1203</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421260" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Cmdl32 has dropped an executable [A0320].</description>
+    <field name="rulename" type="osmatch">Cmdl32 has dropped an executable [A0320]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421270" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Cmdl32 has written a file [A0321].</description>
+    <field name="rulename" type="osmatch">Cmdl32 has written a file [A0321]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421280" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Curl has dropped a suspicious executable [A0322].</description>
+    <field name="rulename" type="osmatch">Curl has dropped a suspicious executable [A0322]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421290" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: IMEwdbld Dropped an Executable [A0323].</description>
+    <field name="rulename" type="osmatch">IMEwdbld Dropped an Executable [A0323]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421300" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious executable copied via RDP clipboard [A0324a].</description>
+    <field name="rulename" type="osmatch">Suspicious executable copied via RDP clipboard [A0324a]</field>
+    <mitre>
+      <id>T1570</id>
+      <id>T1105</id>
+      <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421310" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Executable copied to %WINDIR% via RDP clipboard [A0324c].</description>
+    <field name="rulename" type="osmatch">Executable copied to %WINDIR% via RDP clipboard [A0324c]</field>
+    <mitre>
+      <id>T1570</id>
+      <id>T1105</id>
+      <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421320" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious DLL copied via RDP clipboard [A0325a].</description>
+    <field name="rulename" type="osmatch">Suspicious DLL copied via RDP clipboard [A0325a]</field>
+    <mitre>
+      <id>T1570</id>
+      <id>T1105</id>
+      <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421330" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious DLL copied to %WINDIR% via RDP clipboard [A0325c].</description>
+    <field name="rulename" type="osmatch">Suspicious DLL copied to %WINDIR% via RDP clipboard [A0325c]</field>
+    <mitre>
+      <id>T1570</id>
+      <id>T1105</id>
+      <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421340" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Driver copied via RDP clipboard [A0326].</description>
+    <field name="rulename" type="osmatch">Driver copied via RDP clipboard [A0326]</field>
+    <mitre>
+      <id>T1570</id>
+      <id>T1105</id>
+      <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421350" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Cscript.exe executed process [A0401].</description>
+    <field name="rulename" type="osmatch">Cscript.exe executed process [A0401]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="421360" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Explorer.exe executed script process [A0402].</description>
+    <field name="rulename" type="osmatch">Explorer.exe executed script process [A0402]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+      <id>T1204</id>
+    </mitre>
+  </rule>
+
+  <rule id="421370" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Mshta.exe executed process [A0404].</description>
+    <field name="rulename" type="osmatch">Mshta.exe executed process [A0404]</field>
+    <mitre>
+      <id>T1218.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="421380" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Ntvdm.exe executed process [A0406].</description>
+    <field name="rulename" type="osmatch">Ntvdm.exe executed process [A0406]</field>
+    <mitre>
+      <id>T1059</id>
+    </mitre>
+  </rule>
+
+  <rule id="421390" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Powershell.exe executed unpopular process [A0408].</description>
+    <field name="rulename" type="osmatch">Powershell.exe executed unpopular process [A0408]</field>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421400" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process &quot;explorer.exe&quot; was executed from a non-%WINDIR% folder [A0409].</description>
+    <field name="rulename" type="osmatch">Process &quot;explorer.exe&quot; was executed from a non-%WINDIR% folder [A0409]</field>
+    <mitre>
+      <id>T1036.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="421410" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process has started from Recycle Bin folder [A0412].</description>
+    <field name="rulename" type="osmatch">Process has started from Recycle Bin folder [A0412]</field>
+    <mitre>
+      <id>T1564</id>
+    </mitre>
+  </rule>
+
+  <rule id="421420" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Regsvr32.exe executed script process [A0413].</description>
+    <field name="rulename" type="osmatch">Regsvr32.exe executed script process [A0413]</field>
+    <mitre>
+      <id>T1218.010</id>
+    </mitre>
+  </rule>
+
+  <rule id="421430" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wscript.exe executed a process [A0415].</description>
+    <field name="rulename" type="osmatch">Wscript.exe executed a process [A0415]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="421440" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process executed from ADS [A0417].</description>
+    <field name="rulename" type="osmatch">Process executed from ADS [A0417]</field>
+    <mitre>
+      <id>T1564.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="421450" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Sdbinst.exe tool executed [A0418].</description>
+    <field name="rulename" type="osmatch">Sdbinst.exe tool executed [A0418]</field>
+    <mitre>
+      <id>T1546.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="421460" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: MSBuild.exe from .NET Framework was executed [A0420].</description>
+    <field name="rulename" type="osmatch">MSBuild.exe from .NET Framework was executed [A0420]</field>
+    <mitre>
+      <id>T1127.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421470" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Connection Manager Profile Installer was executed [A0421].</description>
+    <field name="rulename" type="osmatch">Microsoft Connection Manager Profile Installer was executed [A0421]</field>
+    <mitre>
+      <id>T1218.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="421480" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process with mimikatz-like command line parameters executed [A0422].</description>
+    <field name="rulename" type="osmatch">Process with mimikatz-like command line parameters executed [A0422]</field>
+    <mitre>
+      <id>T1134.005</id>
+      <id>T1098</id>
+      <id>T1547.005</id>
+      <id>T1555</id>
+      <id>T1555.003</id>
+      <id>T1003.001</id>
+      <id>T1003.006</id>
+      <id>T1003.002</id>
+      <id>T1003.004</id>
+      <id>T1207</id>
+      <id>T1558.001</id>
+      <id>T1558.002</id>
+      <id>T1552.004</id>
+      <id>T1550.002</id>
+      <id>T1550.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="421490" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process with mimikatz-like executable metadata executed [A0423].</description>
+    <field name="rulename" type="osmatch">Process with mimikatz-like executable metadata executed [A0423]</field>
+    <mitre>
+      <id>T1134.005</id>
+      <id>T1098</id>
+      <id>T1547.005</id>
+      <id>T1555</id>
+      <id>T1555.003</id>
+      <id>T1003.001</id>
+      <id>T1003.006</id>
+      <id>T1003.002</id>
+      <id>T1003.004</id>
+      <id>T1207</id>
+      <id>T1558.001</id>
+      <id>T1558.002</id>
+      <id>T1552.004</id>
+      <id>T1550.002</id>
+      <id>T1550.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="421500" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wmic.exe was executed from script interpreter [A0424b].</description>
+    <field name="rulename" type="osmatch">Wmic.exe was executed from script interpreter [A0424b]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="421510" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wmic.exe was executed by browser [A0424c].</description>
+    <field name="rulename" type="osmatch">Wmic.exe was executed by browser [A0424c]</field>
+    <mitre>
+      <id>T1203</id>
+      <id>T1059.007</id>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="421520" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wmic.exe was executed by Microsoft Office application [A0424d].</description>
+    <field name="rulename" type="osmatch">Wmic.exe was executed by Microsoft Office application [A0424d]</field>
+    <mitre>
+      <id>T1203</id>
+      <id>T1059.005</id>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="421530" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Certutil with download parameter executed [A0425].</description>
+    <field name="rulename" type="osmatch">Certutil with download parameter executed [A0425]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421540" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMIC has processed an Extensible Stylesheet Language (XSL) file [A0426].</description>
+    <field name="rulename" type="osmatch">WMIC has processed an Extensible Stylesheet Language (XSL) file [A0426]</field>
+    <mitre>
+      <id>T1220</id>
+    </mitre>
+  </rule>
+
+  <rule id="421550" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell executed process via WMI [A0427a].</description>
+    <field name="rulename" type="osmatch">PowerShell executed process via WMI [A0427a]</field>
+    <mitre>
+      <id>T1047</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421560" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Script Host executed process via WMI [A0427b].</description>
+    <field name="rulename" type="osmatch">Windows Script Host executed process via WMI [A0427b]</field>
+    <mitre>
+      <id>T1047</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="421570" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office suite executed process via WMI [A0427c].</description>
+    <field name="rulename" type="osmatch">Microsoft Office suite executed process via WMI [A0427c]</field>
+    <mitre>
+      <id>T1047</id>
+      <id>T1059.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="421580" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious process was executed via WMI [A0428a].</description>
+    <field name="rulename" type="osmatch">Suspicious process was executed via WMI [A0428a]</field>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="421590" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious process executed process via WMI [A0428b].</description>
+    <field name="rulename" type="osmatch">Suspicious process executed process via WMI [A0428b]</field>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="421600" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process was executed from remote computer via WMI [A0429].</description>
+    <field name="rulename" type="osmatch">Process was executed from remote computer via WMI [A0429]</field>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="421610" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wmic.exe executed process via WMI [A0430a].</description>
+    <field name="rulename" type="osmatch">Wmic.exe executed process via WMI [A0430a]</field>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="421620" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wmic.exe local process execution command line parameters [A0430b].</description>
+    <field name="rulename" type="osmatch">Wmic.exe local process execution command line parameters [A0430b]</field>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="421630" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wmic.exe remote process execution command line parameters [A0430c].</description>
+    <field name="rulename" type="osmatch">Wmic.exe remote process execution command line parameters [A0430c]</field>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="421640" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Net1.exe not executed from Net tool [A0433].</description>
+    <field name="rulename" type="osmatch">Net1.exe not executed from Net tool [A0433]</field>
+    <mitre>
+      <id>T1087.001</id>
+      <id>T1087.002</id>
+      <id>T1136.001</id>
+      <id>T1136.002</id>
+      <id>T1070.005</id>
+      <id>T1135</id>
+      <id>T1201</id>
+      <id>T1069.001</id>
+      <id>T1069.002</id>
+      <id>T1021.002</id>
+      <id>T1018</id>
+      <id>T1049</id>
+      <id>T1007</id>
+      <id>T1569.002</id>
+      <id>T1124</id>
+    </mitre>
+  </rule>
+
+  <rule id="421650" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious packed process executed [A0436].</description>
+    <field name="rulename" type="osmatch">Suspicious packed process executed [A0436]</field>
+    <mitre>
+      <id>T1027.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="421660" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Encoded Visual Basic script file executed [A0437] .</description>
+    <field name="rulename" type="osmatch">Encoded Visual Basic script file executed [A0437]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1027</id>
+    </mitre>
+  </rule>
+
+  <rule id="421670" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Print Spooler loaded suspicious DLL [A0438][C].</description>
+    <field name="rulename" type="osmatch">Windows Print Spooler loaded suspicious DLL [A0438][C]</field>
+    <mitre>
+      <id>T1068</id>
+      <id>T1203</id>
+    </mitre>
+  </rule>
+
+  <rule id="421680" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC Bypass - clipup.exe Spawned Process [A0439a].</description>
+    <field name="rulename" type="osmatch">Possible UAC Bypass - clipup.exe Spawned Process [A0439a]</field>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="421690" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC Bypass - dismhost.exe Spawned Process [A0439b].</description>
+    <field name="rulename" type="osmatch">Possible UAC Bypass - dismhost.exe Spawned Process [A0439b]</field>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="421700" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC Bypass - winsat.exe Spawned Process [A0439c].</description>
+    <field name="rulename" type="osmatch">Possible UAC Bypass - winsat.exe Spawned Process [A0439c]</field>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="421710" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC Bypass - wsreset Spawned Process [A0439d].</description>
+    <field name="rulename" type="osmatch">Possible UAC Bypass - wsreset Spawned Process [A0439d]</field>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="421720" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC Bypass - dccw.exe Spawned Process [A0439h].</description>
+    <field name="rulename" type="osmatch">Possible UAC Bypass - dccw.exe Spawned Process [A0439h]</field>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="421730" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC Bypass - osk.exe Spawned Process [A0439i].</description>
+    <field name="rulename" type="osmatch">Possible UAC Bypass - osk.exe Spawned Process [A0439i]</field>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="421740" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC Bypass - msconfig.exe Spawned Process [A0439k].</description>
+    <field name="rulename" type="osmatch">Possible UAC Bypass - msconfig.exe Spawned Process [A0439k]</field>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="421750" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC Bypass - changepk.exe Spawned Process [A0439l].</description>
+    <field name="rulename" type="osmatch">Possible UAC Bypass - changepk.exe Spawned Process [A0439l]</field>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="421760" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC bypass - computerdefaults.exe spawned process [A0439m].</description>
+    <field name="rulename" type="osmatch">Possible UAC bypass - computerdefaults.exe spawned process [A0439m]</field>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="421770" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Javascript or VBScript started from startup folder [A0443].</description>
+    <field name="rulename" type="osmatch">Javascript or VBScript started from startup folder [A0443]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="421780" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed 7-Zip execution [A0444].</description>
+    <field name="rulename" type="osmatch">Renamed 7-Zip execution [A0444]</field>
+    <mitre>
+      <id>T1036.003</id>
+      <id>T1560.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421790" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed WinRAR execution [A0445].</description>
+    <field name="rulename" type="osmatch">Renamed WinRAR execution [A0445]</field>
+    <mitre>
+      <id>T1036.003</id>
+      <id>T1560.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421800" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Portproxy creation via netsh [A0446].</description>
+    <field name="rulename" type="osmatch">Portproxy creation via netsh [A0446]</field>
+    <mitre>
+      <id>T1090.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421810" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Finger execution [A0447].</description>
+    <field name="rulename" type="osmatch">Finger execution [A0447]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421820" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Execution of MpCmdRun with download parameter [A0448].</description>
+    <field name="rulename" type="osmatch">Execution of MpCmdRun with download parameter [A0448]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="421830" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Execution of suspicious executable copied via RDP clipboard [A0449a].</description>
+    <field name="rulename" type="osmatch">Execution of suspicious executable copied via RDP clipboard [A0449a]</field>
+    <mitre>
+      <id>T1570</id>
+      <id>T1105</id>
+      <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421840" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Execution of suspicious executable copied via RDP clipboard from %WINDIR% [A0449c].</description>
+    <field name="rulename" type="osmatch">Execution of suspicious executable copied via RDP clipboard from %WINDIR% [A0449c]</field>
+    <mitre>
+      <id>T1570</id>
+      <id>T1105</id>
+      <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421850" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Loading of a suspicious DLL file copied via RDP clipboard [A0450a].</description>
+    <field name="rulename" type="osmatch">Loading of a suspicious DLL file copied via RDP clipboard [A0450a]</field>
+    <mitre>
+      <id>T1570</id>
+      <id>T1105</id>
+      <id>T1021.001</id>
+      <id>T1129</id>
+    </mitre>
+  </rule>
+
+  <rule id="421860" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Loading of a DLL file copied via RDP clipboard from %WINDIR% [A0450c].</description>
+    <field name="rulename" type="osmatch">Loading of a DLL file copied via RDP clipboard from %WINDIR% [A0450c]</field>
+    <mitre>
+      <id>T1570</id>
+      <id>T1105</id>
+      <id>T1021.001</id>
+      <id>T1129</id>
+    </mitre>
+  </rule>
+
+  <rule id="421870" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process cscript.exe creates an internal network connection [A0500a].</description>
+    <field name="rulename" type="osmatch">Process cscript.exe creates an internal network connection [A0500a]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="421880" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process cscript.exe creates an external network connection [A0500b].</description>
+    <field name="rulename" type="osmatch">Process cscript.exe creates an external network connection [A0500b]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="421890" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process ntvdm.exe creates a network connection [A0501].</description>
+    <field name="rulename" type="osmatch">Process ntvdm.exe creates a network connection [A0501]</field>
+    <mitre>
+      <id>T1059</id>
+    </mitre>
+  </rule>
+
+  <rule id="421900" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell Creates an External Network Connection [A0502b].</description>
+    <field name="rulename" type="osmatch">PowerShell Creates an External Network Connection [A0502b]</field>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="421910" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process regsvr32.exe creates a network connection [A0503].</description>
+    <field name="rulename" type="osmatch">Process regsvr32.exe creates a network connection [A0503]</field>
+    <mitre>
+      <id>T1218.010</id>
+    </mitre>
+  </rule>
+
+  <rule id="421920" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Internal network connection from rundll32.exe started from an unpopular process [A0504a].</description>
+    <field name="rulename" type="osmatch">Internal network connection from rundll32.exe started from an unpopular process [A0504a]</field>
+    <mitre>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="421930" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: External network connection from rundll32.exe started from an unpopular process [A0504b].</description>
+    <field name="rulename" type="osmatch">External network connection from rundll32.exe started from an unpopular process [A0504b]</field>
+    <mitre>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="421940" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Internal network connection from wscript.exe [A0505a].</description>
+    <field name="rulename" type="osmatch">Internal network connection from wscript.exe [A0505a]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="421950" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: External network connection from wscript.exe [A0505b].</description>
+    <field name="rulename" type="osmatch">External network connection from wscript.exe [A0505b]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="421960" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Dynamic DNS provider connection [A0506].</description>
+    <field name="rulename" type="osmatch">Dynamic DNS provider connection [A0506]</field>
+    <mitre>
+      <id>T1102</id>
+    </mitre>
+  </rule>
+
+  <rule id="421970" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Tor2Web service connection [A0507].</description>
+    <field name="rulename" type="osmatch">Tor2Web service connection [A0507]</field>
+    <mitre>
+      <id>T1090.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="421980" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Cmd.exe creates an internal network connection [A0511a].</description>
+    <field name="rulename" type="osmatch">Cmd.exe creates an internal network connection [A0511a]</field>
+    <mitre>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="421990" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Cmd.exe creates an external network connection [A0511b].</description>
+    <field name="rulename" type="osmatch">Cmd.exe creates an external network connection [A0511b]</field>
+    <mitre>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="422000" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network connection from Windows Installer (msiexec) [A0512].</description>
+    <field name="rulename" type="osmatch">Network connection from Windows Installer (msiexec) [A0512]</field>
+    <mitre>
+      <id>T1218.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="422010" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network connection accepted by unpopular process [A0516].</description>
+    <field name="rulename" type="osmatch">Network connection accepted by unpopular process [A0516]</field>
+    <mitre>
+      <id>T1090</id>
+      <id>T1205</id>
+    </mitre>
+  </rule>
+
+  <rule id="422020" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: IMAP communication over non-standard port [A0517].</description>
+    <field name="rulename" type="osmatch">IMAP communication over non-standard port [A0517]</field>
+    <mitre>
+      <id>T1571</id>
+      <id>T1071.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="422030" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: POP3 communication over non-standard port [A0518].</description>
+    <field name="rulename" type="osmatch">POP3 communication over non-standard port [A0518]</field>
+    <mitre>
+      <id>T1571</id>
+      <id>T1071.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="422040" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PortProxy registry was modified [A0519].</description>
+    <field name="rulename" type="osmatch">PortProxy registry was modified [A0519]</field>
+    <mitre>
+      <id>T1090.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422050" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Multiple file writes from an unpopular process [A0601].</description>
+    <field name="rulename" type="osmatch">Multiple file writes from an unpopular process [A0601]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="422060" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Multiple file renames from an unpopular process [A0602].</description>
+    <field name="rulename" type="osmatch">Multiple file renames from an unpopular process [A0602]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="422070" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Ransomware-like data written to file [A0603].</description>
+    <field name="rulename" type="osmatch">Ransomware-like data written to file [A0603]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="422080" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: RAR tool encrypts files [A0604].</description>
+    <field name="rulename" type="osmatch">RAR tool encrypts files [A0604]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="422090" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: RAR with Turla-like command line [A0605].</description>
+    <field name="rulename" type="osmatch">RAR with Turla-like command line [A0605]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="422100" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Multiple file writes from a compromised process [A0606].</description>
+    <field name="rulename" type="osmatch">Multiple file writes from a compromised process [A0606]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="422110" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Multiple file renames from a compromised process [A0607].</description>
+    <field name="rulename" type="osmatch">Multiple file renames from a compromised process [A0607]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="422120" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Multiple file writes from a script interpreter [A0608].</description>
+    <field name="rulename" type="osmatch">Multiple file writes from a script interpreter [A0608]</field>
+    <mitre>
+      <id>T1486</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+      <id>T1218.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="422130" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Multiple file renames from a script interpreter [A0609].</description>
+    <field name="rulename" type="osmatch">Multiple file renames from a script interpreter [A0609]</field>
+    <mitre>
+      <id>T1486</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+      <id>T1218.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="422140" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Multiple file writes from PowerShell [A0610].</description>
+    <field name="rulename" type="osmatch">Multiple file writes from PowerShell [A0610]</field>
+    <mitre>
+      <id>T1486</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="422150" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Multiple file renames from PowerShell [A0611].</description>
+    <field name="rulename" type="osmatch">Multiple file renames from PowerShell [A0611]</field>
+    <mitre>
+      <id>T1486</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="422160" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Internet Explorer Extensions registry was modified [A0700].</description>
+    <field name="rulename" type="osmatch">Internet Explorer Extensions registry was modified [A0700]</field>
+    <mitre>
+      <id>T1176</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422170" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Internet Explorer UrlSearchHooks registry entry was modified [A0701].</description>
+    <field name="rulename" type="osmatch">Internet Explorer UrlSearchHooks registry entry was modified [A0701]</field>
+    <mitre>
+      <id>T1176</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422180" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Internet Explorer JavaScript profiler registry was modified [A0702].</description>
+    <field name="rulename" type="osmatch">Internet Explorer JavaScript profiler registry was modified [A0702]</field>
+    <mitre>
+      <id>T1574</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422190" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office Addins registry entry was modified by an unpopular process [A0800].</description>
+    <field name="rulename" type="osmatch">Microsoft Office Addins registry entry was modified by an unpopular process [A0800]</field>
+    <mitre>
+      <id>T1137.006</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422200" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office Test registry entry was modified [A0801].</description>
+    <field name="rulename" type="osmatch">Microsoft Office Test registry entry was modified [A0801]</field>
+    <mitre>
+      <id>T1137.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422210" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Outlook mapi32.dll registry was modified [A0802].</description>
+    <field name="rulename" type="osmatch">Microsoft Outlook mapi32.dll registry was modified [A0802]</field>
+    <mitre>
+      <id>T1137</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422220" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: MS Office application has executed certutil [A0804].</description>
+    <field name="rulename" type="osmatch">MS Office application has executed certutil [A0804]</field>
+    <mitre>
+      <id>T1059.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="422230" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: MS Office application has executed bitsadmin [A0805].</description>
+    <field name="rulename" type="osmatch">MS Office application has executed bitsadmin [A0805]</field>
+    <mitre>
+      <id>T1059.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="422240" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Desktop ClxDllPath registry modified [A0900].</description>
+    <field name="rulename" type="osmatch">Remote Desktop ClxDllPath registry modified [A0900]</field>
+    <mitre>
+      <id>T1021.001</id>
+      <id>T1574</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422250" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Desktop TestDVCPlugin registry modified [A0901].</description>
+    <field name="rulename" type="osmatch">Remote Desktop TestDVCPlugin registry modified [A0901]</field>
+    <mitre>
+      <id>T1021.001</id>
+      <id>T1574</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422260" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PsExec named pipe created [A0904].</description>
+    <field name="rulename" type="osmatch">PsExec named pipe created [A0904]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="422270" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote execution using renamed PsExec service [A0905].</description>
+    <field name="rulename" type="osmatch">Remote execution using renamed PsExec service [A0905]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="422280" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Psexec.py command line [A0906].</description>
+    <field name="rulename" type="osmatch">Psexec.py command line [A0906]</field>
+    <mitre>
+      <id>T1059.006</id>
+      <id>T1569.002</id>
+      <id>T1021.002</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="422290" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Domain user added to administrator group [A1001].</description>
+    <field name="rulename" type="osmatch">Domain user added to administrator group [A1001]</field>
+    <mitre>
+      <id>T1098</id>
+    </mitre>
+  </rule>
+
+  <rule id="422300" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Domain user created [A1002].</description>
+    <field name="rulename" type="osmatch">Domain user created [A1002]</field>
+    <mitre>
+      <id>T1136.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="422310" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Test signing mode enabled [A1003].</description>
+    <field name="rulename" type="osmatch">Test signing mode enabled [A1003]</field>
+    <mitre>
+      <id>T1553.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="422320" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Dsquery was executed [A1100].</description>
+    <field name="rulename" type="osmatch">Dsquery was executed [A1100]</field>
+    <mitre>
+      <id>T1087.002</id>
+      <id>T1482</id>
+      <id>T1069.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="422330" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: DNS zone transfer request [A1101].</description>
+    <field name="rulename" type="osmatch">DNS zone transfer request [A1101]</field>
+    <mitre>
+      <id>T1016</id>
+    </mitre>
+  </rule>
+
+  <rule id="422340" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: GetWindowText API string in AMSI script [A1102].</description>
+    <field name="rulename" type="osmatch">GetWindowText API string in AMSI script [A1102]</field>
+    <mitre>
+      <id>T1010</id>
+    </mitre>
+  </rule>
+
+  <rule id="422350" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: MainWindowTitle property string in PowerShell [A1103].</description>
+    <field name="rulename" type="osmatch">MainWindowTitle property string in PowerShell [A1103]</field>
+    <mitre>
+      <id>T1010</id>
+    </mitre>
+  </rule>
+
+  <rule id="422360" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious process queried users/groups information via WMI [A1105a].</description>
+    <field name="rulename" type="osmatch">Suspicious process queried users/groups information via WMI [A1105a]</field>
+    <mitre>
+      <id>T1087.001</id>
+      <id>T1087.002</id>
+      <id>T1069.001</id>
+      <id>T1069.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="422370" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wmic.exe queried users/groups information via WMI [A1105b].</description>
+    <field name="rulename" type="osmatch">Wmic.exe queried users/groups information via WMI [A1105b]</field>
+    <mitre>
+      <id>T1087.001</id>
+      <id>T1087.002</id>
+      <id>T1069.001</id>
+      <id>T1069.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="422380" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell queried users/groups information via WMI [A1105c].</description>
+    <field name="rulename" type="osmatch">PowerShell queried users/groups information via WMI [A1105c]</field>
+    <mitre>
+      <id>T1087.001</id>
+      <id>T1087.002</id>
+      <id>T1069.001</id>
+      <id>T1069.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="422390" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious process queried system owner/user information via WMI [A1106a].</description>
+    <field name="rulename" type="osmatch">Suspicious process queried system owner/user information via WMI [A1106a]</field>
+    <mitre>
+      <id>T1033</id>
+    </mitre>
+  </rule>
+
+  <rule id="422400" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wmic.exe queried system owner/user information via WMI [A1106b].</description>
+    <field name="rulename" type="osmatch">Wmic.exe queried system owner/user information via WMI [A1106b]</field>
+    <mitre>
+      <id>T1033</id>
+    </mitre>
+  </rule>
+
+  <rule id="422410" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell queried system owner/user information via WMI [A1106c].</description>
+    <field name="rulename" type="osmatch">PowerShell queried system owner/user information via WMI [A1106c]</field>
+    <mitre>
+      <id>T1033</id>
+    </mitre>
+  </rule>
+
+  <rule id="422420" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious process queried files/folders information via WMI [A1107a].</description>
+    <field name="rulename" type="osmatch">Suspicious process queried files/folders information via WMI [A1107a]</field>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="422430" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wmic.exe queried files/folders information via WMI [A1107b].</description>
+    <field name="rulename" type="osmatch">Wmic.exe queried files/folders information via WMI [A1107b]</field>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="422440" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell queried files/folders information via WMI [A1107c].</description>
+    <field name="rulename" type="osmatch">PowerShell queried files/folders information via WMI [A1107c]</field>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="422450" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Script interpreter queried files/folders information via WMI [A1107d].</description>
+    <field name="rulename" type="osmatch">Script interpreter queried files/folders information via WMI [A1107d]</field>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="422460" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Script interpreter queried network configuration information via WMI [A1109d].</description>
+    <field name="rulename" type="osmatch">Script interpreter queried network configuration information via WMI [A1109d]</field>
+    <mitre>
+      <id>T1016</id>
+    </mitre>
+  </rule>
+
+  <rule id="422470" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Invoke-WCMDump cmdlet [A1116].</description>
+    <field name="rulename" type="osmatch">Invoke-WCMDump cmdlet [A1116]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1555.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="422480" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell shellcode APIs [A1200].</description>
+    <field name="rulename" type="osmatch">PowerShell shellcode APIs [A1200]</field>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="422490" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Loading of driver file copied via RDP clipboard [A1300].</description>
+    <field name="rulename" type="osmatch">Loading of driver file copied via RDP clipboard [A1300]</field>
+    <mitre>
+      <id>T1570</id>
+      <id>T1105</id>
+      <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="422500" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Scheduling task on system start/login [B0101].</description>
+    <field name="rulename" type="osmatch">Scheduling task on system start/login [B0101]</field>
+    <mitre>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="422510" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Winlogon Notify registration [B0102].</description>
+    <field name="rulename" type="osmatch">Winlogon Notify registration [B0102]</field>
+    <mitre>
+      <id>T1547.004</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422520" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: ShellExecute hook creation [B0103].</description>
+    <field name="rulename" type="osmatch">ShellExecute hook creation [B0103]</field>
+    <mitre>
+      <id>T1546</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422530" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Command Processor AutoRun registry was modified [B0104].</description>
+    <field name="rulename" type="osmatch">Command Processor AutoRun registry was modified [B0104]</field>
+    <mitre>
+      <id>T1546</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422540" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User Account Control disabling [B0201].</description>
+    <field name="rulename" type="osmatch">User Account Control disabling [B0201]</field>
+    <mitre>
+      <id>T1548</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422550" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Firewall rules manipulation [B0202].</description>
+    <field name="rulename" type="osmatch">Windows Firewall rules manipulation [B0202]</field>
+    <mitre>
+      <id>T1562.004</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422560" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious executable with .dll extension was dropped [B0301].</description>
+    <field name="rulename" type="osmatch">Suspicious executable with .dll extension was dropped [B0301]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="422570" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious desktop link creation [B0302].</description>
+    <field name="rulename" type="osmatch">Suspicious desktop link creation [B0302]</field>
+    <mitre>
+      <id>T1547.009</id>
+    </mitre>
+  </rule>
+
+  <rule id="422580" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious executable with .exe extension was dropped [B0304].</description>
+    <field name="rulename" type="osmatch">Suspicious executable with .exe extension was dropped [B0304]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="422590" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Processes killing from command line [B0401].</description>
+    <field name="rulename" type="osmatch">Processes killing from command line [B0401]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="422600" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Service installation or modification [B0402].</description>
+    <field name="rulename" type="osmatch">Service installation or modification [B0402]</field>
+    <mitre>
+      <id>T1543.003</id>
+      <id>T1569.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422610" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Service Management via Command Line Tools [B0403].</description>
+    <field name="rulename" type="osmatch">Service Management via Command Line Tools [B0403]</field>
+    <mitre>
+      <id>T1543.003</id>
+      <id>T1569.002</id>
+      <id>T1007</id>
+    </mitre>
+  </rule>
+
+  <rule id="422620" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: cmd.exe executed under a different name [B0404][C].</description>
+    <field name="rulename" type="osmatch">cmd.exe executed under a different name [B0404][C]</field>
+    <mitre>
+      <id>T1036.003</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="422630" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Trusted non-Microsoft process loaded suspicious DLL [B0406a].</description>
+    <field name="rulename" type="osmatch">Trusted non-Microsoft process loaded suspicious DLL [B0406a]</field>
+    <mitre>
+      <id>T1574.001</id>
+      <id>T1574.002</id>
+      <id>T1218</id>
+    </mitre>
+  </rule>
+
+  <rule id="422640" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Trusted Microsoft process loaded suspicious DLL [B0406c].</description>
+    <field name="rulename" type="osmatch">Trusted Microsoft process loaded suspicious DLL [B0406c]</field>
+    <mitre>
+      <id>T1574.001</id>
+      <id>T1574.002</id>
+      <id>T1218</id>
+    </mitre>
+  </rule>
+
+  <rule id="422650" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: LSASS Loaded Suspicious DLL [B0408].</description>
+    <field name="rulename" type="osmatch">LSASS Loaded Suspicious DLL [B0408]</field>
+    <mitre>
+      <id>T1003.001</id>
+      <id>T1556.002</id>
+      <id>T1547.008</id>
+    </mitre>
+  </rule>
+
+  <rule id="422660" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious execution using RunDLL32 [B0409].</description>
+    <field name="rulename" type="osmatch">Suspicious execution using RunDLL32 [B0409]</field>
+    <mitre>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="422670" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Querying IP info [B0504].</description>
+    <field name="rulename" type="osmatch">Querying IP info [B0504]</field>
+    <mitre>
+      <id>T1016</id>
+    </mitre>
+  </rule>
+
+  <rule id="422680" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Exploit kit (Rig-v) - suspicious communication [B0505].</description>
+    <field name="rulename" type="osmatch">Exploit kit (Rig-v) - suspicious communication [B0505]</field>
+    <mitre>
+      <id>T1189</id>
+      <id>T1203</id>
+    </mitre>
+  </rule>
+
+  <rule id="422690" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Exploit kit (Sundown) - possible suspicious communication [B0506].</description>
+    <field name="rulename" type="osmatch">Exploit kit (Sundown) - possible suspicious communication [B0506]</field>
+    <mitre>
+      <id>T1189</id>
+      <id>T1203</id>
+    </mitre>
+  </rule>
+
+  <rule id="422700" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: RAR encrypts and deletes files [B0601].</description>
+    <field name="rulename" type="osmatch">RAR encrypts and deletes files [B0601]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="422710" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Chrome executing suspicious extension [B0703].</description>
+    <field name="rulename" type="osmatch">Chrome executing suspicious extension [B0703]</field>
+    <mitre>
+      <id>T1176</id>
+    </mitre>
+  </rule>
+
+  <rule id="422720" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office protected view was modified [B0801].</description>
+    <field name="rulename" type="osmatch">Microsoft Office protected view was modified [B0801]</field>
+    <mitre>
+      <id>T1562</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422730" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote execution using PsExec [B0901].</description>
+    <field name="rulename" type="osmatch">Remote execution using PsExec [B0901]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="422740" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Service Executed [B0902].</description>
+    <field name="rulename" type="osmatch">Suspicious Service Executed [B0902]</field>
+    <mitre>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="422750" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Silent execution of PsExec [B0903].</description>
+    <field name="rulename" type="osmatch">Silent execution of PsExec [B0903]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1569.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422760" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Clearing event logs [B1001].</description>
+    <field name="rulename" type="osmatch">Clearing event logs [B1001]</field>
+    <mitre>
+      <id>T1070.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="422770" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User/group management from command line [B1003].</description>
+    <field name="rulename" type="osmatch">User/group management from command line [B1003]</field>
+    <mitre>
+      <id>T1098</id>
+      <id>T1136</id>
+      <id>T1531</id>
+    </mitre>
+  </rule>
+
+  <rule id="422780" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Setting a dangerous boot configuration [B1004].</description>
+    <field name="rulename" type="osmatch">Setting a dangerous boot configuration [B1004]</field>
+    <mitre>
+      <id>T1490</id>
+    </mitre>
+  </rule>
+
+  <rule id="422790" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Deleting Backup with Wbadmin [B1005].</description>
+    <field name="rulename" type="osmatch">Deleting Backup with Wbadmin [B1005]</field>
+    <mitre>
+      <id>T1490</id>
+    </mitre>
+  </rule>
+
+  <rule id="422800" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Writes Suspicious Link File [C0101].</description>
+    <field name="rulename" type="osmatch">Process Writes Suspicious Link File [C0101]</field>
+    <mitre>
+      <id>T1547.009</id>
+    </mitre>
+  </rule>
+
+  <rule id="422810" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI Event Filter to Consumer Binding via wmic [C0102].</description>
+    <field name="rulename" type="osmatch">WMI Event Filter to Consumer Binding via wmic [C0102]</field>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="422820" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI Command-line Event Consumer Creation via wmic [C0103].</description>
+    <field name="rulename" type="osmatch">WMI Command-line Event Consumer Creation via wmic [C0103]</field>
+    <mitre>
+      <id>T1546.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="422830" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI Event Filter Creation via wmic [C0104].</description>
+    <field name="rulename" type="osmatch">WMI Event Filter Creation via wmic [C0104]</field>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="422840" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI ActiveScript Event Consumer Creation via wmic [C0105].</description>
+    <field name="rulename" type="osmatch">WMI ActiveScript Event Consumer Creation via wmic [C0105]</field>
+    <mitre>
+      <id>T1546.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="422850" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: ESET Registry Key Has Been Set [C0201a].</description>
+    <field name="rulename" type="osmatch">ESET Registry Key Has Been Set [C0201a]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422860" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: ESET Registry Key Has Been Set [C0201b].</description>
+    <field name="rulename" type="osmatch">ESET Registry Key Has Been Set [C0201b]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422870" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: ESET Service Registry Key Has Been Set [C0202].</description>
+    <field name="rulename" type="osmatch">ESET Service Registry Key Has Been Set [C0202]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="422880" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Command Prompt Enabled via Registry [C0203].</description>
+    <field name="rulename" type="osmatch">Command Prompt Enabled via Registry [C0203]</field>
+    <mitre>
+      <id>T1112</id>
+      <id>T1562.001</id>
+      <id>T1059.001</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="422890" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Local PowerShell ExecutionPolicy Was Set to Unrestricted [C0204].</description>
+    <field name="rulename" type="osmatch">Local PowerShell ExecutionPolicy Was Set to Unrestricted [C0204]</field>
+    <mitre>
+      <id>T1562</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="422900" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Deletion via PowerShell [C0301a].</description>
+    <field name="rulename" type="osmatch">File Deletion via PowerShell [C0301a]</field>
+    <mitre>
+      <id>T1070.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="422910" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Deletion via PowerShell [C0301b].</description>
+    <field name="rulename" type="osmatch">File Deletion via PowerShell [C0301b]</field>
+    <mitre>
+      <id>T1070.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="422920" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Permissions Modification Attempt via PowerShell [C0302a].</description>
+    <field name="rulename" type="osmatch">File Permissions Modification Attempt via PowerShell [C0302a]</field>
+    <mitre>
+      <id>T1222.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="422930" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Permissions Modification Attempt via PowerShell [C0302b].</description>
+    <field name="rulename" type="osmatch">File Permissions Modification Attempt via PowerShell [C0302b]</field>
+    <mitre>
+      <id>T1222.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="422940" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Permissions Modification Attempt via PowerShell [C0302c].</description>
+    <field name="rulename" type="osmatch">File Permissions Modification Attempt via PowerShell [C0302c]</field>
+    <mitre>
+      <id>T1222.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="422950" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Important System File Deletion [C0308].</description>
+    <field name="rulename" type="osmatch">Important System File Deletion [C0308]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="422960" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Image/Container File Deleted by Suspicious Executable [C0311a].</description>
+    <field name="rulename" type="osmatch">Image/Container File Deleted by Suspicious Executable [C0311a]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="422970" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Image/Container File Deleted by Command-line Interpreter [C0311b].</description>
+    <field name="rulename" type="osmatch">Image/Container File Deleted by Command-line Interpreter [C0311b]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="422980" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Snapshot Related File Deleted by Suspicious Executable [C0312a].</description>
+    <field name="rulename" type="osmatch">Snapshot Related File Deleted by Suspicious Executable [C0312a]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="422990" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Snapshot Related File Deleted by Command-line Interpreter [C0312b].</description>
+    <field name="rulename" type="osmatch">Snapshot Related File Deleted by Command-line Interpreter [C0312b]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="423000" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Diskpart.exe executed [C0313].</description>
+    <field name="rulename" type="osmatch">Diskpart.exe executed [C0313]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="423010" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: format.com executed [C0314].</description>
+    <field name="rulename" type="osmatch">format.com executed [C0314]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="423020" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious fsutil file command executed [C0315].</description>
+    <field name="rulename" type="osmatch">Suspicious fsutil file command executed [C0315]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="423030" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: fsutil volume dismount command executed [C0316].</description>
+    <field name="rulename" type="osmatch">fsutil volume dismount command executed [C0316]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="423040" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: fsutil wim removewim command executed [C0317].</description>
+    <field name="rulename" type="osmatch">fsutil wim removewim command executed [C0317]</field>
+    <mitre>
+      <id>T1490</id>
+    </mitre>
+  </rule>
+
+  <rule id="423050" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File written into minidump folder [C0318].</description>
+    <field name="rulename" type="osmatch">File written into minidump folder [C0318]</field>
+    <mitre>
+      <id>T1499</id>
+    </mitre>
+  </rule>
+
+  <rule id="423060" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious process has written file into boot folder [C0319].</description>
+    <field name="rulename" type="osmatch">Suspicious process has written file into boot folder [C0319]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423070" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious process has written HTML file into program files folder [C0320].</description>
+    <field name="rulename" type="osmatch">Suspicious process has written HTML file into program files folder [C0320]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423080" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious process has written file into cd-rom [C0321].</description>
+    <field name="rulename" type="osmatch">Suspicious process has written file into cd-rom [C0321]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423090" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious attrib command via cmd.exe [C0323].</description>
+    <field name="rulename" type="osmatch">Suspicious attrib command via cmd.exe [C0323]</field>
+    <mitre>
+      <id>T1222.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423100" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious process has deleted file from system backup [C0325].</description>
+    <field name="rulename" type="osmatch">Suspicious process has deleted file from system backup [C0325]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="423110" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious process has written file into system backup folder [C0326].</description>
+    <field name="rulename" type="osmatch">Suspicious process has written file into system backup folder [C0326]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423120" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: NTDS.dit file has been written [C0328].</description>
+    <field name="rulename" type="osmatch">NTDS.dit file has been written [C0328]</field>
+    <mitre>
+      <id>T1003.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423130" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File is written into ESET folder [C0330].</description>
+    <field name="rulename" type="osmatch">File is written into ESET folder [C0330]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423140" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File deleted from ESET folder [C0331].</description>
+    <field name="rulename" type="osmatch">File deleted from ESET folder [C0331]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423150" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Deletes Driver File [C0332].</description>
+    <field name="rulename" type="osmatch">Process Deletes Driver File [C0332]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="423160" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Cipher Executes With W Parameter [C0334].</description>
+    <field name="rulename" type="osmatch">Process Cipher Executes With W Parameter [C0334]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="423170" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Deletes Critical File [C0335].</description>
+    <field name="rulename" type="osmatch">Process Deletes Critical File [C0335]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="423180" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Deletes Executable From Windows Folder [C0336].</description>
+    <field name="rulename" type="osmatch">Process Deletes Executable From Windows Folder [C0336]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="423190" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Deletes File From System Volume Information Folder [C0337].</description>
+    <field name="rulename" type="osmatch">Process Deletes File From System Volume Information Folder [C0337]</field>
+    <mitre>
+      <id>T1490</id>
+    </mitre>
+  </rule>
+
+  <rule id="423200" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Process Deletes File From Temp Folder [C0338].</description>
+    <field name="rulename" type="osmatch">System Process Deletes File From Temp Folder [C0338]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="423210" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Deletes File From SoftwareDistribution Folder [C0339].</description>
+    <field name="rulename" type="osmatch">Process Deletes File From SoftwareDistribution Folder [C0339]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="423220" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to modify or delete shadow copies [C0401a].</description>
+    <field name="rulename" type="osmatch">Attempt to modify or delete shadow copies [C0401a]</field>
+    <mitre>
+      <id>T1490</id>
+    </mitre>
+  </rule>
+
+  <rule id="423230" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to remove shadow copies through PowerShell [C0401b].</description>
+    <field name="rulename" type="osmatch">Attempt to remove shadow copies through PowerShell [C0401b]</field>
+    <mitre>
+      <id>T1490</id>
+      <id>T1047</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423240" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell script tries to modify or delete shadow copies [C0401c].</description>
+    <field name="rulename" type="osmatch">PowerShell script tries to modify or delete shadow copies [C0401c]</field>
+    <mitre>
+      <id>T1490</id>
+      <id>T1047</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423250" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Third-Party Software Uninstaller Executed [C0402].</description>
+    <field name="rulename" type="osmatch">Third-Party Software Uninstaller Executed [C0402]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423260" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Service execution via PowerShell [C0405a].</description>
+    <field name="rulename" type="osmatch">Service execution via PowerShell [C0405a]</field>
+    <mitre>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="423270" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Service execution via PowerShell [C0405b].</description>
+    <field name="rulename" type="osmatch">Service execution via PowerShell [C0405b]</field>
+    <mitre>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="423280" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: New service creation attempt via PowerShell [C0406a].</description>
+    <field name="rulename" type="osmatch">New service creation attempt via PowerShell [C0406a]</field>
+    <mitre>
+      <id>T1543.003</id>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="423290" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: New service creation attempt via PowerShell [C0406b].</description>
+    <field name="rulename" type="osmatch">New service creation attempt via PowerShell [C0406b]</field>
+    <mitre>
+      <id>T1543.003</id>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="423300" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: New service creation attempt via PowerShell [C0406c].</description>
+    <field name="rulename" type="osmatch">New service creation attempt via PowerShell [C0406c]</field>
+    <mitre>
+      <id>T1543.003</id>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="423310" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: shutdown.exe executed [C0408].</description>
+    <field name="rulename" type="osmatch">shutdown.exe executed [C0408]</field>
+    <mitre>
+      <id>T1529</id>
+    </mitre>
+  </rule>
+
+  <rule id="423320" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: shutdown.exe for remote PC executed [C0409].</description>
+    <field name="rulename" type="osmatch">shutdown.exe for remote PC executed [C0409]</field>
+    <mitre>
+      <id>T1529</id>
+    </mitre>
+  </rule>
+
+  <rule id="423330" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: bcdedit.exe executed [C0410].</description>
+    <field name="rulename" type="osmatch">bcdedit.exe executed [C0410]</field>
+    <mitre>
+      <id>T1490</id>
+    </mitre>
+  </rule>
+
+  <rule id="423340" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: bcdboot.exe executed [C0411].</description>
+    <field name="rulename" type="osmatch">bcdboot.exe executed [C0411]</field>
+    <mitre>
+      <id>T1490</id>
+    </mitre>
+  </rule>
+
+  <rule id="423350" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: wbadmin.exe executed [C0412].</description>
+    <field name="rulename" type="osmatch">wbadmin.exe executed [C0412]</field>
+    <mitre>
+      <id>T1490</id>
+    </mitre>
+  </rule>
+
+  <rule id="423360" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: systemreset.exe executed [C0413].</description>
+    <field name="rulename" type="osmatch">systemreset.exe executed [C0413]</field>
+    <mitre>
+      <id>T1485</id>
+      <id>T1592</id>
+    </mitre>
+  </rule>
+
+  <rule id="423370" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: vssadmin.exe executed [C0414].</description>
+    <field name="rulename" type="osmatch">vssadmin.exe executed [C0414]</field>
+    <mitre>
+      <id>T1490</id>
+    </mitre>
+  </rule>
+
+  <rule id="423380" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to stop security account manager [C0417].</description>
+    <field name="rulename" type="osmatch">Attempt to stop security account manager [C0417]</field>
+    <mitre>
+      <id>T1489</id>
+    </mitre>
+  </rule>
+
+  <rule id="423390" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: reagentc.exe executed [C0418].</description>
+    <field name="rulename" type="osmatch">reagentc.exe executed [C0418]</field>
+    <mitre>
+      <id>T1490</id>
+    </mitre>
+  </rule>
+
+  <rule id="423400" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious systemreset command executed [C0419].</description>
+    <field name="rulename" type="osmatch">Suspicious systemreset command executed [C0419]</field>
+    <mitre>
+      <id>T1485</id>
+      <id>T1592</id>
+    </mitre>
+  </rule>
+
+  <rule id="423410" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: takeown.exe executed [C0420].</description>
+    <field name="rulename" type="osmatch">takeown.exe executed [C0420]</field>
+    <mitre>
+      <id>T1222.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423420" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicous cacls command executed [C0422].</description>
+    <field name="rulename" type="osmatch">Suspicous cacls command executed [C0422]</field>
+    <mitre>
+      <id>T1222.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423430" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to load PowerView script [C0424].</description>
+    <field name="rulename" type="osmatch">Attempt to load PowerView script [C0424]</field>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423440" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: w32tm.exe executed [C0425].</description>
+    <field name="rulename" type="osmatch">w32tm.exe executed [C0425]</field>
+    <mitre>
+      <id>T1124</id>
+    </mitre>
+  </rule>
+
+  <rule id="423450" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with suspicious name has been executed [C0426].</description>
+    <field name="rulename" type="osmatch">File with suspicious name has been executed [C0426]</field>
+    <mitre>
+      <id>T1204</id>
+    </mitre>
+  </rule>
+
+  <rule id="423460" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious file name in command content [C0427].</description>
+    <field name="rulename" type="osmatch">Suspicious file name in command content [C0427]</field>
+    <mitre>
+      <id>T1204</id>
+    </mitre>
+  </rule>
+
+  <rule id="423470" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: rubeus.exe executed [C0428].</description>
+    <field name="rulename" type="osmatch">rubeus.exe executed [C0428]</field>
+    <mitre>
+      <id>T1558.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423480" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: rubeus.exe hashes dump for *roast attempt [C0429].</description>
+    <field name="rulename" type="osmatch">rubeus.exe hashes dump for *roast attempt [C0429]</field>
+    <mitre>
+      <id>T1558.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423490" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: rubeus in command-line [C0430].</description>
+    <field name="rulename" type="osmatch">rubeus in command-line [C0430]</field>
+    <mitre>
+      <id>T1558.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423500" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Kerberoast attempt through PowerShell [C0431].</description>
+    <field name="rulename" type="osmatch">Kerberoast attempt through PowerShell [C0431]</field>
+    <mitre>
+      <id>T1558.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423510" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: SharpChrome.exe executed [C0432].</description>
+    <field name="rulename" type="osmatch">SharpChrome.exe executed [C0432]</field>
+    <mitre>
+      <id>T1555.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423520" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: SharpChrome in command-line [C0433].</description>
+    <field name="rulename" type="osmatch">SharpChrome in command-line [C0433]</field>
+    <mitre>
+      <id>T1555.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423530" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Net-GPPPassword.exe executed [C0434].</description>
+    <field name="rulename" type="osmatch">Net-GPPPassword.exe executed [C0434]</field>
+    <mitre>
+      <id>T1552.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="423540" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Net-GPPPassword in command-line [C0435].</description>
+    <field name="rulename" type="osmatch">Net-GPPPassword in command-line [C0435]</field>
+    <mitre>
+      <id>T1552.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="423550" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: SharpDump.exe executed [C0436].</description>
+    <field name="rulename" type="osmatch">SharpDump.exe executed [C0436]</field>
+    <mitre>
+      <id>T1003.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423560" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: SharpDump in command-line [C0437].</description>
+    <field name="rulename" type="osmatch">SharpDump in command-line [C0437]</field>
+    <mitre>
+      <id>T1003.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423570" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Dump attempt in command-line [C0438].</description>
+    <field name="rulename" type="osmatch">Dump attempt in command-line [C0438]</field>
+    <mitre>
+      <id>T1003.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423580" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Get-GPPPassword command through PowerShell [C0439].</description>
+    <field name="rulename" type="osmatch">Get-GPPPassword command through PowerShell [C0439]</field>
+    <mitre>
+      <id>T1552.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="423590" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to add registry item [C0440].</description>
+    <field name="rulename" type="osmatch">Attempt to add registry item [C0440]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="423600" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to get AnyDesk ID [C0441].</description>
+    <field name="rulename" type="osmatch">Attempt to get AnyDesk ID [C0441]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="423610" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious start command [C0442].</description>
+    <field name="rulename" type="osmatch">Suspicious start command [C0442]</field>
+    <mitre>
+      <id>T1059</id>
+    </mitre>
+  </rule>
+
+  <rule id="423620" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Querying run registry item through command [C0443].</description>
+    <field name="rulename" type="osmatch">Querying run registry item through command [C0443]</field>
+    <mitre>
+      <id>T1012</id>
+    </mitre>
+  </rule>
+
+  <rule id="423630" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to start volume shadow copy service [C0444].</description>
+    <field name="rulename" type="osmatch">Attempt to start volume shadow copy service [C0444]</field>
+    <mitre>
+      <id>T1003.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423640" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to set AnyDesk password [C0445].</description>
+    <field name="rulename" type="osmatch">Attempt to set AnyDesk password [C0445]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="423650" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to create suspicious scheduled task [C0446].</description>
+    <field name="rulename" type="osmatch">Attempt to create suspicious scheduled task [C0446]</field>
+    <mitre>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="423660" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious keyword in command content [C0447].</description>
+    <field name="rulename" type="osmatch">Suspicious keyword in command content [C0447]</field>
+    <mitre>
+      <id>T1059</id>
+    </mitre>
+  </rule>
+
+  <rule id="423670" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Service failure command [C0448].</description>
+    <field name="rulename" type="osmatch">Service failure command [C0448]</field>
+    <mitre>
+      <id>T1543.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423680" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: fiddler.exe executed [C0449].</description>
+    <field name="rulename" type="osmatch">fiddler.exe executed [C0449]</field>
+    <mitre>
+      <id>T1557</id>
+    </mitre>
+  </rule>
+
+  <rule id="423690" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Esentutl in command-line [C0450].</description>
+    <field name="rulename" type="osmatch">Esentutl in command-line [C0450]</field>
+    <mitre>
+      <id>T1005</id>
+      <id>T1564.004</id>
+      <id>T1105</id>
+      <id>T1570</id>
+      <id>T1003.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423700" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to copy ntds.dit file [C0451].</description>
+    <field name="rulename" type="osmatch">Attempt to copy ntds.dit file [C0451]</field>
+    <mitre>
+      <id>T1003.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423710" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to create shadow copy [C0452].</description>
+    <field name="rulename" type="osmatch">Attempt to create shadow copy [C0452]</field>
+    <mitre>
+      <id>T1003.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423720" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to list shadow copies [C0453].</description>
+    <field name="rulename" type="osmatch">Attempt to list shadow copies [C0453]</field>
+    <mitre>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="423730" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Attempt to turn off firewall through netsh [C0454].</description>
+    <field name="rulename" type="osmatch">Attempt to turn off firewall through netsh [C0454]</field>
+    <mitre>
+      <id>T1562.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="423740" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Tor application executed [C0457].</description>
+    <field name="rulename" type="osmatch">Tor application executed [C0457]</field>
+    <mitre>
+      <id>T1090.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423750" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Ngrok Executed [C0458].</description>
+    <field name="rulename" type="osmatch">Ngrok Executed [C0458]</field>
+    <mitre>
+      <id>T1572</id>
+    </mitre>
+  </rule>
+
+  <rule id="423760" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible data exfiltration through rclone [C0459].</description>
+    <field name="rulename" type="osmatch">Possible data exfiltration through rclone [C0459]</field>
+    <mitre>
+      <id>T1567.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="423770" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Secure process crash/hang [C0460].</description>
+    <field name="rulename" type="osmatch">Secure process crash/hang [C0460]</field>
+    <mitre>
+      <id>T1203</id>
+    </mitre>
+  </rule>
+
+  <rule id="423780" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell Deletes Critical Service [C0461].</description>
+    <field name="rulename" type="osmatch">PowerShell Deletes Critical Service [C0461]</field>
+    <mitre>
+      <id>T1489</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423790" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Command Stops Monitored Service [C0462].</description>
+    <field name="rulename" type="osmatch">Command Stops Monitored Service [C0462]</field>
+    <mitre>
+      <id>T1489</id>
+    </mitre>
+  </rule>
+
+  <rule id="423800" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: ESET Uninstaller/AV Remover Executed [C0480].</description>
+    <field name="rulename" type="osmatch">ESET Uninstaller/AV Remover Executed [C0480]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423810" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: IObit Unlocker Executed [C0481].</description>
+    <field name="rulename" type="osmatch">IObit Unlocker Executed [C0481]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="423820" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Kernel Mode Driver Registered by a Suspicious Process [C0482].</description>
+    <field name="rulename" type="osmatch">Kernel Mode Driver Registered by a Suspicious Process [C0482]</field>
+    <mitre>
+      <id>T1068</id>
+      <id>T1543.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="423830" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious IE4Uinit Execution - INF Sideload [C0483].</description>
+    <field name="rulename" type="osmatch">Suspicious IE4Uinit Execution - INF Sideload [C0483]</field>
+    <mitre>
+      <id>T1218</id>
+    </mitre>
+  </rule>
+
+  <rule id="423840" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network share connection removal via PowerShell [C0501a].</description>
+    <field name="rulename" type="osmatch">Network share connection removal via PowerShell [C0501a]</field>
+    <mitre>
+      <id>T1070.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="423850" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network share connection removal via PowerShell [C0501b].</description>
+    <field name="rulename" type="osmatch">Network share connection removal via PowerShell [C0501b]</field>
+    <mitre>
+      <id>T1070.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="423860" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network share connection removal via PowerShell [C0501c].</description>
+    <field name="rulename" type="osmatch">Network share connection removal via PowerShell [C0501c]</field>
+    <mitre>
+      <id>T1070.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="423870" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Port Forwarding - ssh.exe [C0503].</description>
+    <field name="rulename" type="osmatch">Remote Port Forwarding - ssh.exe [C0503]</field>
+    <mitre>
+      <id>T1572</id>
+    </mitre>
+  </rule>
+
+  <rule id="423880" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with extension used by Win32/Filecoder.GandCrab has been written [C0605].</description>
+    <field name="rulename" type="osmatch">File with extension used by Win32/Filecoder.GandCrab has been written [C0605]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423890" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Bad extension - filecoders (set 0) [C0606].</description>
+    <field name="rulename" type="osmatch">Bad extension - filecoders (set 0) [C0606]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423900" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Bad extension - filecoders (set 1) [C0607].</description>
+    <field name="rulename" type="osmatch">Bad extension - filecoders (set 1) [C0607]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423910" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Bad extension - filecoders (set 2) [C0608].</description>
+    <field name="rulename" type="osmatch">Bad extension - filecoders (set 2) [C0608]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423920" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Bad extension - filecoders (set 3) [C0609].</description>
+    <field name="rulename" type="osmatch">Bad extension - filecoders (set 3) [C0609]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423930" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File probably encrypted with filecoder [C0610].</description>
+    <field name="rulename" type="osmatch">File probably encrypted with filecoder [C0610]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423940" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Ransomnote file was written - filecoders [C0611].</description>
+    <field name="rulename" type="osmatch">Ransomnote file was written - filecoders [C0611]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423950" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Bad extension - filecoders (extension parts) [C0612].</description>
+    <field name="rulename" type="osmatch">Bad extension - filecoders (extension parts) [C0612]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423960" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with extension used by Win32/Filecoder.Crysis has been written [C0613].</description>
+    <field name="rulename" type="osmatch">File with extension used by Win32/Filecoder.Crysis has been written [C0613]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423970" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Win32/Filecoder.WannaCryptor clue has been found [C0614].</description>
+    <field name="rulename" type="osmatch">Win32/Filecoder.WannaCryptor clue has been found [C0614]</field>
+    <mitre>
+      <id>T1486</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="423980" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with extension used by Win32/Filecoder.BTCWare has been written [C0615].</description>
+    <field name="rulename" type="osmatch">File with extension used by Win32/Filecoder.BTCWare has been written [C0615]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="423990" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File used by Win32/Diskcoder.C has been written [C0616].</description>
+    <field name="rulename" type="osmatch">File used by Win32/Diskcoder.C has been written [C0616]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424000" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File used by Win32/Diskcoder.D has been written [C0617].</description>
+    <field name="rulename" type="osmatch">File used by Win32/Diskcoder.D has been written [C0617]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424010" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File used by DiskCryptor application has been written [C0618].</description>
+    <field name="rulename" type="osmatch">File used by DiskCryptor application has been written [C0618]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424020" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Ransomnote behavioral detection - filecoders [C0619].</description>
+    <field name="rulename" type="osmatch">Ransomnote behavioral detection - filecoders [C0619]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424030" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with extension used by Win32/Filecoder.FV has been written [C0620].</description>
+    <field name="rulename" type="osmatch">File with extension used by Win32/Filecoder.FV has been written [C0620]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424040" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with extension used by Win32/Filecoder.FS has been written [C0621].</description>
+    <field name="rulename" type="osmatch">File with extension used by Win32/Filecoder.FS has been written [C0621]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424050" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious file extension [C0622].</description>
+    <field name="rulename" type="osmatch">Suspicious file extension [C0622]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424060" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with extension used by Win32/Filecoder.LockedFile has been written [C0623].</description>
+    <field name="rulename" type="osmatch">File with extension used by Win32/Filecoder.LockedFile has been written [C0623]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424070" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with extension used by Win32/Filecoder.STOP has been written [C0624].</description>
+    <field name="rulename" type="osmatch">File with extension used by Win32/Filecoder.STOP has been written [C0624]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424080" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with extension used by Win32/Filecoder.Phobos has been written [C0625].</description>
+    <field name="rulename" type="osmatch">File with extension used by Win32/Filecoder.Phobos has been written [C0625]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424090" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with extension used by Win32/Filecoder.Ryuk has been written [C0626].</description>
+    <field name="rulename" type="osmatch">File with extension used by Win32/Filecoder.Ryuk has been written [C0626]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424100" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with extension used by Win32/Filecoder.Ouroboros has been written [C0627].</description>
+    <field name="rulename" type="osmatch">File with extension used by Win32/Filecoder.Ouroboros has been written [C0627]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424110" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with unexpected extension is written into documents folder [C0628].</description>
+    <field name="rulename" type="osmatch">File with unexpected extension is written into documents folder [C0628]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424120" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with extension used by Win32/Filecoder.WastedLocker has been written [C0629].</description>
+    <field name="rulename" type="osmatch">File with extension used by Win32/Filecoder.WastedLocker has been written [C0629]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424130" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Win32/Filecoder.WastedLocker installation behavior [C0630].</description>
+    <field name="rulename" type="osmatch">Win32/Filecoder.WastedLocker installation behavior [C0630]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424140" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Setting registry item specific to Win32/Filecoder.Sodinokibi [C0631].</description>
+    <field name="rulename" type="osmatch">Setting registry item specific to Win32/Filecoder.Sodinokibi [C0631]</field>
+    <mitre>
+      <id>T1486</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424150" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Setting registry item specific to Win32/Filecoder.Buran [C0632].</description>
+    <field name="rulename" type="osmatch">Setting registry item specific to Win32/Filecoder.Buran [C0632]</field>
+    <mitre>
+      <id>T1486</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424160" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Setting registry item specific to Win32/Filecoder.Magniber [C0633].</description>
+    <field name="rulename" type="osmatch">Setting registry item specific to Win32/Filecoder.Magniber [C0633]</field>
+    <mitre>
+      <id>T1486</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424170" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Http request to url specific to Win32/Filecoder.Nemty [C0634].</description>
+    <field name="rulename" type="osmatch">Http request to url specific to Win32/Filecoder.Nemty [C0634]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424180" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Http request to url specific to Win32/Filecoder.ODM (SunCrypt) [C0635].</description>
+    <field name="rulename" type="osmatch">Http request to url specific to Win32/Filecoder.ODM (SunCrypt) [C0635]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424190" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Http request to url specific to Win32/Filecoder.Egregor [C0636].</description>
+    <field name="rulename" type="osmatch">Http request to url specific to Win32/Filecoder.Egregor [C0636]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424200" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Dharma ransomware toolkit item file name was written [C0637].</description>
+    <field name="rulename" type="osmatch">Dharma ransomware toolkit item file name was written [C0637]</field>
+    <mitre>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="424210" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Netwalker ransomware toolkit item file name was written [C0638].</description>
+    <field name="rulename" type="osmatch">Netwalker ransomware toolkit item file name was written [C0638]</field>
+    <mitre>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="424220" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with name containing keyword used by Win32/Filecoder.RagnarLocker was written [C0639].</description>
+    <field name="rulename" type="osmatch">File with name containing keyword used by Win32/Filecoder.RagnarLocker was written [C0639]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424230" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with name format used by Win32/Filecoder.BlackCat has been written [C0642].</description>
+    <field name="rulename" type="osmatch">File with name format used by Win32/Filecoder.BlackCat has been written [C0642]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424240" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Win64/Filecoder.Hansom artefacts [C0643].</description>
+    <field name="rulename" type="osmatch">Win64/Filecoder.Hansom artefacts [C0643]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="424250" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Browser Credential Store Access - Python Application [C0701a].</description>
+    <field name="rulename" type="osmatch">Browser Credential Store Access - Python Application [C0701a]</field>
+    <mitre>
+      <id>T1555.003</id>
+      <id>T1059.006</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="424260" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Browser Credential Store Access - Unpopular Process [C0701b].</description>
+    <field name="rulename" type="osmatch">Browser Credential Store Access - Unpopular Process [C0701b]</field>
+    <mitre>
+      <id>T1555.003</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="424270" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: NetSupport Manager Executed from Unusual Location [C0901].</description>
+    <field name="rulename" type="osmatch">NetSupport Manager Executed from Unusual Location [C0901]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="424280" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: KillDisk specific registry item has been added [C1001].</description>
+    <field name="rulename" type="osmatch">KillDisk specific registry item has been added [C1001]</field>
+    <mitre>
+      <id>T1499</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424290" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows error reporting disabled in registry [C1003].</description>
+    <field name="rulename" type="osmatch">Windows error reporting disabled in registry [C1003]</field>
+    <mitre>
+      <id>T1489</id>
+      <id>T1564</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424300" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows error reporting - DumpFolder key has been set in registry [C1004].</description>
+    <field name="rulename" type="osmatch">Windows error reporting - DumpFolder key has been set in registry [C1004]</field>
+    <mitre>
+      <id>T1564</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424310" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Updates - auto-update disabled in registry [C1005].</description>
+    <field name="rulename" type="osmatch">Windows Updates - auto-update disabled in registry [C1005]</field>
+    <mitre>
+      <id>T1562</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424320" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Updates - auto-restart enabled in registry [C1006].</description>
+    <field name="rulename" type="osmatch">Windows Updates - auto-restart enabled in registry [C1006]</field>
+    <mitre>
+      <id>T1499</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424330" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Updates - wrong WUServer item value [C1007].</description>
+    <field name="rulename" type="osmatch">Windows Updates - wrong WUServer item value [C1007]</field>
+    <mitre>
+      <id>T1562</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424340" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Updates - scheduled auto-restart enabled in registry [C1008].</description>
+    <field name="rulename" type="osmatch">Windows Updates - scheduled auto-restart enabled in registry [C1008]</field>
+    <mitre>
+      <id>T1499</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424350" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious process has changed PendingFileRenameOperations item in Windows registry [C1009].</description>
+    <field name="rulename" type="osmatch">Suspicious process has changed PendingFileRenameOperations item in Windows registry [C1009]</field>
+    <mitre>
+      <id>T1485</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424360" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Disabling RDP authentication [C1010].</description>
+    <field name="rulename" type="osmatch">Disabling RDP authentication [C1010]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424370" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Registry key set to hide user account on login screen [C1011].</description>
+    <field name="rulename" type="osmatch">Registry key set to hide user account on login screen [C1011]</field>
+    <mitre>
+      <id>T1564.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424380" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wallpaper registry item has been set [C1012].</description>
+    <field name="rulename" type="osmatch">Wallpaper registry item has been set [C1012]</field>
+    <mitre>
+      <id>T1491.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424390" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell Disables System Restore [C1013b].</description>
+    <field name="rulename" type="osmatch">PowerShell Disables System Restore [C1013b]</field>
+    <mitre>
+      <id>T1490</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="424400" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Is Setting LockScreenImage in Windows Registry [C1014].</description>
+    <field name="rulename" type="osmatch">Process Is Setting LockScreenImage in Windows Registry [C1014]</field>
+    <mitre>
+      <id>T1491.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="424410" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System service discovery via PowerShell [C1101a].</description>
+    <field name="rulename" type="osmatch">System service discovery via PowerShell [C1101a]</field>
+    <mitre>
+      <id>T1007</id>
+    </mitre>
+  </rule>
+
+  <rule id="424420" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System service discovery via PowerShell [C1101b].</description>
+    <field name="rulename" type="osmatch">System service discovery via PowerShell [C1101b]</field>
+    <mitre>
+      <id>T1007</id>
+    </mitre>
+  </rule>
+
+  <rule id="424430" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Query registry via PowerShell [C1102a].</description>
+    <field name="rulename" type="osmatch">Query registry via PowerShell [C1102a]</field>
+    <mitre>
+      <id>T1012</id>
+    </mitre>
+  </rule>
+
+  <rule id="424440" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Query registry via PowerShell [C1102b].</description>
+    <field name="rulename" type="osmatch">Query registry via PowerShell [C1102b]</field>
+    <mitre>
+      <id>T1012</id>
+    </mitre>
+  </rule>
+
+  <rule id="424450" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Query registry via PowerShell [C1102c].</description>
+    <field name="rulename" type="osmatch">Query registry via PowerShell [C1102c]</field>
+    <mitre>
+      <id>T1012</id>
+    </mitre>
+  </rule>
+
+  <rule id="424460" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System network configuration discovery via PowerShell [C1103a].</description>
+    <field name="rulename" type="osmatch">System network configuration discovery via PowerShell [C1103a]</field>
+    <mitre>
+      <id>T1016</id>
+    </mitre>
+  </rule>
+
+  <rule id="424470" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System network configuration discovery via PowerShell [C1103b].</description>
+    <field name="rulename" type="osmatch">System network configuration discovery via PowerShell [C1103b]</field>
+    <mitre>
+      <id>T1016</id>
+    </mitre>
+  </rule>
+
+  <rule id="424480" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System network configuration discovery through PowerShell [C1103c].</description>
+    <field name="rulename" type="osmatch">System network configuration discovery through PowerShell [C1103c]</field>
+    <mitre>
+      <id>T1016</id>
+    </mitre>
+  </rule>
+
+  <rule id="424490" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote system discovery via PowerShell [C1104a].</description>
+    <field name="rulename" type="osmatch">Remote system discovery via PowerShell [C1104a]</field>
+    <mitre>
+      <id>T1018</id>
+    </mitre>
+  </rule>
+
+  <rule id="424500" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote system discovery via PowerShell [C1104b].</description>
+    <field name="rulename" type="osmatch">Remote system discovery via PowerShell [C1104b]</field>
+    <mitre>
+      <id>T1018</id>
+    </mitre>
+  </rule>
+
+  <rule id="424510" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote system discovery via PowerShell [C1104c].</description>
+    <field name="rulename" type="osmatch">Remote system discovery via PowerShell [C1104c]</field>
+    <mitre>
+      <id>T1018</id>
+    </mitre>
+  </rule>
+
+  <rule id="424520" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System owner/user discovery via PowerShell [C1105a].</description>
+    <field name="rulename" type="osmatch">System owner/user discovery via PowerShell [C1105a]</field>
+    <mitre>
+      <id>T1033</id>
+    </mitre>
+  </rule>
+
+  <rule id="424530" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System owner/user discovery via PowerShell [C1105b].</description>
+    <field name="rulename" type="osmatch">System owner/user discovery via PowerShell [C1105b]</field>
+    <mitre>
+      <id>T1033</id>
+    </mitre>
+  </rule>
+
+  <rule id="424540" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System owner/user discovery via PowerShell [C1105c].</description>
+    <field name="rulename" type="osmatch">System owner/user discovery via PowerShell [C1105c]</field>
+    <mitre>
+      <id>T1033</id>
+    </mitre>
+  </rule>
+
+  <rule id="424550" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System network connections discovery via PowerShell [C1106a].</description>
+    <field name="rulename" type="osmatch">System network connections discovery via PowerShell [C1106a]</field>
+    <mitre>
+      <id>T1049</id>
+    </mitre>
+  </rule>
+
+  <rule id="424560" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System network connections discovery via PowerShell [C1106b].</description>
+    <field name="rulename" type="osmatch">System network connections discovery via PowerShell [C1106b]</field>
+    <mitre>
+      <id>T1049</id>
+    </mitre>
+  </rule>
+
+  <rule id="424570" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System network connections discovery via PowerShell [C1106c].</description>
+    <field name="rulename" type="osmatch">System network connections discovery via PowerShell [C1106c]</field>
+    <mitre>
+      <id>T1049</id>
+    </mitre>
+  </rule>
+
+  <rule id="424580" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process discovery via PowerShell [C1107a].</description>
+    <field name="rulename" type="osmatch">Process discovery via PowerShell [C1107a]</field>
+    <mitre>
+      <id>T1057</id>
+    </mitre>
+  </rule>
+
+  <rule id="424590" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process discovery via PowerShell [C1107b].</description>
+    <field name="rulename" type="osmatch">Process discovery via PowerShell [C1107b]</field>
+    <mitre>
+      <id>T1057</id>
+    </mitre>
+  </rule>
+
+  <rule id="424600" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process discovery via PowerShell [C1107c].</description>
+    <field name="rulename" type="osmatch">Process discovery via PowerShell [C1107c]</field>
+    <mitre>
+      <id>T1057</id>
+    </mitre>
+  </rule>
+
+  <rule id="424610" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Permission groups discovery via PowerShell [C1108a].</description>
+    <field name="rulename" type="osmatch">Permission groups discovery via PowerShell [C1108a]</field>
+    <mitre>
+      <id>T1069</id>
+    </mitre>
+  </rule>
+
+  <rule id="424620" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Permission groups discovery via PowerShell [C1108b].</description>
+    <field name="rulename" type="osmatch">Permission groups discovery via PowerShell [C1108b]</field>
+    <mitre>
+      <id>T1069</id>
+    </mitre>
+  </rule>
+
+  <rule id="424630" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Permission groups discovery via PowerShell [C1108c].</description>
+    <field name="rulename" type="osmatch">Permission groups discovery via PowerShell [C1108c]</field>
+    <mitre>
+      <id>T1069</id>
+    </mitre>
+  </rule>
+
+  <rule id="424640" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File and directory discovery via PowerShell [C1109a].</description>
+    <field name="rulename" type="osmatch">File and directory discovery via PowerShell [C1109a]</field>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="424650" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File and directory discovery via PowerShell [C1109b].</description>
+    <field name="rulename" type="osmatch">File and directory discovery via PowerShell [C1109b]</field>
+    <mitre>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="424660" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Account discovery via PowerShell [C1110a].</description>
+    <field name="rulename" type="osmatch">Account discovery via PowerShell [C1110a]</field>
+    <mitre>
+      <id>T1087.001</id>
+      <id>T1087.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="424670" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Silent network scanning via netscan [C1111].</description>
+    <field name="rulename" type="osmatch">Silent network scanning via netscan [C1111]</field>
+    <mitre>
+      <id>T1046</id>
+    </mitre>
+  </rule>
+
+  <rule id="424680" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Enumeration for privilege escalation through windows-exploit-suggester [C1112a].</description>
+    <field name="rulename" type="osmatch">Enumeration for privilege escalation through windows-exploit-suggester [C1112a]</field>
+    <mitre>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="424690" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Enumeration for privilege escalation through SharpUp application [C1112b].</description>
+    <field name="rulename" type="osmatch">Enumeration for privilege escalation through SharpUp application [C1112b]</field>
+    <mitre>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="424700" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Enterprise admins group members discovery via net.exe [C1113].</description>
+    <field name="rulename" type="osmatch">Enterprise admins group members discovery via net.exe [C1113]</field>
+    <mitre>
+      <id>T1069.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="424710" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Domain users discovery via net.exe [C1114].</description>
+    <field name="rulename" type="osmatch">Domain users discovery via net.exe [C1114]</field>
+    <mitre>
+      <id>T1087.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="424720" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote host enumeration via Net/ADFind [C1115].</description>
+    <field name="rulename" type="osmatch">Remote host enumeration via Net/ADFind [C1115]</field>
+    <mitre>
+      <id>T1018</id>
+    </mitre>
+  </rule>
+
+  <rule id="424730" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User group enumeration via Net/ADFind [C1116].</description>
+    <field name="rulename" type="osmatch">User group enumeration via Net/ADFind [C1116]</field>
+    <mitre>
+      <id>T1069</id>
+    </mitre>
+  </rule>
+
+  <rule id="424740" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File share enumeration via net.exe [C1117a].</description>
+    <field name="rulename" type="osmatch">File share enumeration via net.exe [C1117a]</field>
+    <mitre>
+      <id>T1135</id>
+    </mitre>
+  </rule>
+
+  <rule id="424750" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File share enumberation via PowerShell script (Sharefinder.ps1) [C1117b].</description>
+    <field name="rulename" type="osmatch">File share enumberation via PowerShell script (Sharefinder.ps1) [C1117b]</field>
+    <mitre>
+      <id>T1135</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="424760" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Domain trust enumeration via NLTest/ADFind [C1118].</description>
+    <field name="rulename" type="osmatch">Domain trust enumeration via NLTest/ADFind [C1118]</field>
+    <mitre>
+      <id>T1482</id>
+    </mitre>
+  </rule>
+
+  <rule id="424770" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Organizational units discovery through adfind command [C1119].</description>
+    <field name="rulename" type="osmatch">Organizational units discovery through adfind command [C1119]</field>
+    <mitre>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="424780" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Subnets discovery through adfind command [C1120].</description>
+    <field name="rulename" type="osmatch">Subnets discovery through adfind command [C1120]</field>
+    <mitre>
+      <id>T1016</id>
+    </mitre>
+  </rule>
+
+  <rule id="424790" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Time discovery through net command [C1122].</description>
+    <field name="rulename" type="osmatch">Time discovery through net command [C1122]</field>
+    <mitre>
+      <id>T1124</id>
+    </mitre>
+  </rule>
+
+  <rule id="424800" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network sessions discovery via net.exe [C1123].</description>
+    <field name="rulename" type="osmatch">Network sessions discovery via net.exe [C1123]</field>
+    <mitre>
+      <id>T1049</id>
+    </mitre>
+  </rule>
+
+  <rule id="424810" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Inbound RDP Port Allowed via Netsh [C1201].</description>
+    <field name="rulename" type="osmatch">Inbound RDP Port Allowed via Netsh [C1201]</field>
+    <mitre>
+      <id>T1562.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="424820" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious PowerShell Script - Startup [D0101].</description>
+    <field name="rulename" type="osmatch">Suspicious PowerShell Script - Startup [D0101]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1053.005</id>
+      <id>T1547.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="424830" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Script Host Loaded Task Scheduler DLL [D0103].</description>
+    <field name="rulename" type="osmatch">Windows Script Host Loaded Task Scheduler DLL [D0103]</field>
+    <mitre>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="424840" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI Event Subscription Persistence [D0106].</description>
+    <field name="rulename" type="osmatch">WMI Event Subscription Persistence [D0106]</field>
+    <mitre>
+      <id>T1546.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="424850" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible PowerShell Profile Persistence [D0107].</description>
+    <field name="rulename" type="osmatch">Possible PowerShell Profile Persistence [D0107]</field>
+    <mitre>
+      <id>T1546.013</id>
+    </mitre>
+  </rule>
+
+  <rule id="424860" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell Microsoft Exchange Transport Agent Install [D0108].</description>
+    <field name="rulename" type="osmatch">PowerShell Microsoft Exchange Transport Agent Install [D0108]</field>
+    <mitre>
+      <id>T1505.002</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="424870" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Internet Settings NLA Proxy Registry Key Modification [D0209].</description>
+    <field name="rulename" type="osmatch">Internet Settings NLA Proxy Registry Key Modification [D0209]</field>
+    <mitre>
+      <id>T1185</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424880" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Task Manager Disabled in Registry [D0214].</description>
+    <field name="rulename" type="osmatch">Task Manager Disabled in Registry [D0214]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424890" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Root Certificate Added [D0215].</description>
+    <field name="rulename" type="osmatch">Root Certificate Added [D0215]</field>
+    <mitre>
+      <id>T1553.004</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424900" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Remote Management Service Set to Automatic Start [D0216].</description>
+    <field name="rulename" type="osmatch">Windows Remote Management Service Set to Automatic Start [D0216]</field>
+    <mitre>
+      <id>T1021.006</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424910" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: UAC bypass registry modifications [D0217].</description>
+    <field name="rulename" type="osmatch">UAC bypass registry modifications [D0217]</field>
+    <mitre>
+      <id>T1548.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424920" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office MacroRuntimeScanScope Registry Modification [D0218].</description>
+    <field name="rulename" type="osmatch">Microsoft Office MacroRuntimeScanScope Registry Modification [D0218]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424930" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office Trusted Locations Registry Modification [D0219].</description>
+    <field name="rulename" type="osmatch">Microsoft Office Trusted Locations Registry Modification [D0219]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424940" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Downgrade Windows to Windows Preinstallation Environment [D0220].</description>
+    <field name="rulename" type="osmatch">Downgrade Windows to Windows Preinstallation Environment [D0220]</field>
+    <mitre>
+      <id>T1562.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424950" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: LSA Security Support Provider Modification [D0221].</description>
+    <field name="rulename" type="osmatch">LSA Security Support Provider Modification [D0221]</field>
+    <mitre>
+      <id>T1547.005</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424960" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Process Modified PATH Environment Variable [D0222].</description>
+    <field name="rulename" type="osmatch">Suspicious Process Modified PATH Environment Variable [D0222]</field>
+    <mitre>
+      <id>T1574.007</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="424970" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Executable Written to Remote Network Share [D0323].</description>
+    <field name="rulename" type="osmatch">Executable Written to Remote Network Share [D0323]</field>
+    <mitre>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="424980" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Moved from Remote Desktop Client Computer [D0324].</description>
+    <field name="rulename" type="osmatch">File Moved from Remote Desktop Client Computer [D0324]</field>
+    <mitre>
+      <id>T1570</id>
+      <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="424990" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Copied Through TeamViewer [D0325].</description>
+    <field name="rulename" type="osmatch">File Copied Through TeamViewer [D0325]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425000" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Copied Through LogMeIn GoToMyPC [D0326].</description>
+    <field name="rulename" type="osmatch">File Copied Through LogMeIn GoToMyPC [D0326]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425010" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Copied Through TightVNC [D0327].</description>
+    <field name="rulename" type="osmatch">File Copied Through TightVNC [D0327]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425020" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious PowerShell Script - Credentials Stealing [D0328].</description>
+    <field name="rulename" type="osmatch">Suspicious PowerShell Script - Credentials Stealing [D0328]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1555.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="425030" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Grant Full Access to Filesystem Path [D0329].</description>
+    <field name="rulename" type="osmatch">Grant Full Access to Filesystem Path [D0329]</field>
+    <mitre>
+      <id>T1222.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425040" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell Shadow Volumes Registry Hive Copy [D0330].</description>
+    <field name="rulename" type="osmatch">PowerShell Shadow Volumes Registry Hive Copy [D0330]</field>
+    <mitre>
+      <id>T1003.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="425050" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Reading Sensitive Files from Shadow Volume [D0331].</description>
+    <field name="rulename" type="osmatch">Reading Sensitive Files from Shadow Volume [D0331]</field>
+    <mitre>
+      <id>T1003.003</id>
+      <id>T1003.002</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="425060" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Turla ComRAT Hidden File System Artifacts [D0333].</description>
+    <field name="rulename" type="osmatch">Turla ComRAT Hidden File System Artifacts [D0333]</field>
+    <mitre>
+      <id>T1564.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="425070" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Canary File was Triggered [D0334].</description>
+    <field name="rulename" type="osmatch">Canary File was Triggered [D0334]</field>
+    <mitre>
+      <id>T1485</id>
+      <id>T1486</id>
+      <id>T1565</id>
+    </mitre>
+  </rule>
+
+  <rule id="425080" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: LNK File Created on Removable Drive [D0335].</description>
+    <field name="rulename" type="osmatch">LNK File Created on Removable Drive [D0335]</field>
+    <mitre>
+      <id>T1204.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="425090" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PDF Reader Spawns Script Interpreter [D0405].</description>
+    <field name="rulename" type="osmatch">PDF Reader Spawns Script Interpreter [D0405]</field>
+    <mitre>
+      <id>T1203</id>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="425100" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed rundll32.exe Execution [D0408].</description>
+    <field name="rulename" type="osmatch">Renamed rundll32.exe Execution [D0408]</field>
+    <mitre>
+      <id>T1036.003</id>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="425110" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed cscript.exe Execution [D0409].</description>
+    <field name="rulename" type="osmatch">Renamed cscript.exe Execution [D0409]</field>
+    <mitre>
+      <id>T1036.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="425120" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed wscript.exe Execution [D0410].</description>
+    <field name="rulename" type="osmatch">Renamed wscript.exe Execution [D0410]</field>
+    <mitre>
+      <id>T1036.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="425130" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed PowerShell Execution [D0411].</description>
+    <field name="rulename" type="osmatch">Renamed PowerShell Execution [D0411]</field>
+    <mitre>
+      <id>T1036.003</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425140" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious PowerShell Activity - Keywords [D0412].</description>
+    <field name="rulename" type="osmatch">Suspicious PowerShell Activity - Keywords [D0412]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1105</id>
+      <id>T1140</id>
+    </mitre>
+  </rule>
+
+  <rule id="425150" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Unpopular process executed from Rar/7zip sfx [D0416].</description>
+    <field name="rulename" type="osmatch">Unpopular process executed from Rar/7zip sfx [D0416]</field>
+    <mitre>
+      <id>T1027.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="425160" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Certutil with Decode Parameter Executed [D0425].</description>
+    <field name="rulename" type="osmatch">Certutil with Decode Parameter Executed [D0425]</field>
+    <mitre>
+      <id>T1140</id>
+      <id>T1027</id>
+    </mitre>
+  </rule>
+
+  <rule id="425170" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File executed from Remote Desktop Client computer (tsclient) [D0432].</description>
+    <field name="rulename" type="osmatch">File executed from Remote Desktop Client computer (tsclient) [D0432]</field>
+    <mitre>
+      <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425180" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious PowerShell script - UAC Bypass [D0433].</description>
+    <field name="rulename" type="osmatch">Suspicious PowerShell script - UAC Bypass [D0433]</field>
+    <mitre>
+      <id>T1548.002</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425190" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious PowerShell script - Containing C# code execution [D0434].</description>
+    <field name="rulename" type="osmatch">Suspicious PowerShell script - Containing C# code execution [D0434]</field>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425200" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC bypass - DLL Loaded [D0435].</description>
+    <field name="rulename" type="osmatch">Possible UAC bypass - DLL Loaded [D0435]</field>
+    <mitre>
+      <id>T1548.002</id>
+      <id>T1574.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425210" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible UAC Bypass [D0436].</description>
+    <field name="rulename" type="osmatch">Possible UAC Bypass [D0436]</field>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="425220" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Desktopimgdownldr Execution with Suspicious Extension [D0440a].</description>
+    <field name="rulename" type="osmatch">Desktopimgdownldr Execution with Suspicious Extension [D0440a]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="425230" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Desktopimgdownldr download with suspicious extension [D0440b].</description>
+    <field name="rulename" type="osmatch">Desktopimgdownldr download with suspicious extension [D0440b]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="425240" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible Windows Vault enumeration using vaultcmd [D0441].</description>
+    <field name="rulename" type="osmatch">Possible Windows Vault enumeration using vaultcmd [D0441]</field>
+    <mitre>
+      <id>T1555.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="425250" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: AnyDesk Remote Desktop Silent Installation [D0443].</description>
+    <field name="rulename" type="osmatch">AnyDesk Remote Desktop Silent Installation [D0443]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425260" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: BITS Started with SetNotifyCmdLine Parameter [D0444].</description>
+    <field name="rulename" type="osmatch">BITS Started with SetNotifyCmdLine Parameter [D0444]</field>
+    <mitre>
+      <id>T1197</id>
+    </mitre>
+  </rule>
+
+  <rule id="425270" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Unpopular process executed from BITS [D0445].</description>
+    <field name="rulename" type="osmatch">Unpopular process executed from BITS [D0445]</field>
+    <mitre>
+      <id>T1197</id>
+    </mitre>
+  </rule>
+
+  <rule id="425280" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Registry dump of SAM or LSA Secrets [D0446].</description>
+    <field name="rulename" type="osmatch">Registry dump of SAM or LSA Secrets [D0446]</field>
+    <mitre>
+      <id>T1003.002</id>
+      <id>T1003.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="425290" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: CobaltStrike rundll32.exe Default Entrypoint [D0447].</description>
+    <field name="rulename" type="osmatch">CobaltStrike rundll32.exe Default Entrypoint [D0447]</field>
+    <mitre>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="425300" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: DLL Execution by Windows Update Client [D0448].</description>
+    <field name="rulename" type="osmatch">DLL Execution by Windows Update Client [D0448]</field>
+    <mitre>
+      <id>T1218</id>
+    </mitre>
+  </rule>
+
+  <rule id="425310" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: MSDT Protocol Abuse in Command Line [D0449].</description>
+    <field name="rulename" type="osmatch">MSDT Protocol Abuse in Command Line [D0449]</field>
+    <mitre>
+      <id>T1218</id>
+    </mitre>
+  </rule>
+
+  <rule id="425320" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Executed Renamed plink.exe [D0450].</description>
+    <field name="rulename" type="osmatch">Executed Renamed plink.exe [D0450]</field>
+    <mitre>
+      <id>T1036</id>
+      <id>T1572</id>
+    </mitre>
+  </rule>
+
+  <rule id="425330" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible LNK Abuse from ISO - Side-Loading DLL [D0451].</description>
+    <field name="rulename" type="osmatch">Possible LNK Abuse from ISO - Side-Loading DLL [D0451]</field>
+    <mitre>
+      <id>T1204.002</id>
+      <id>T1553.005</id>
+      <id>T1574.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="425340" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible LNK Abuse from ISO - System Binary Proxy Execution [D0452].</description>
+    <field name="rulename" type="osmatch">Possible LNK Abuse from ISO - System Binary Proxy Execution [D0452]</field>
+    <mitre>
+      <id>T1204.002</id>
+      <id>T1553.005</id>
+      <id>T1218.008</id>
+      <id>T1218.010</id>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="425350" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible LNK Abuse from ISO - Living Off The Land Binary [D0453].</description>
+    <field name="rulename" type="osmatch">Possible LNK Abuse from ISO - Living Off The Land Binary [D0453]</field>
+    <mitre>
+      <id>T1204.002</id>
+      <id>T1553.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="425360" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Key Manager Dialog Usage [D0454].</description>
+    <field name="rulename" type="osmatch">Key Manager Dialog Usage [D0454]</field>
+    <mitre>
+      <id>T1555.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="425370" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible LNK Abuse from ISO - Command Execution [D0455].</description>
+    <field name="rulename" type="osmatch">Possible LNK Abuse from ISO - Command Execution [D0455]</field>
+    <mitre>
+      <id>T1204.002</id>
+      <id>T1553.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="425380" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Unquoted Service Path Abuse - Execution [D0458].</description>
+    <field name="rulename" type="osmatch">Unquoted Service Path Abuse - Execution [D0458]</field>
+    <mitre>
+      <id>T1574.009</id>
+    </mitre>
+  </rule>
+
+  <rule id="425390" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Process Loaded Volume Shadow Copy Services API DLL [D0459].</description>
+    <field name="rulename" type="osmatch">Suspicious Process Loaded Volume Shadow Copy Services API DLL [D0459]</field>
+    <mitre>
+      <id>T1490</id>
+    </mitre>
+  </rule>
+
+  <rule id="425400" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible PowerShell Keylogger Script [D0460].</description>
+    <field name="rulename" type="osmatch">Possible PowerShell Keylogger Script [D0460]</field>
+    <mitre>
+      <id>T1056.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425410" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: LNK Abuse from Accessibility Feature [D0461].</description>
+    <field name="rulename" type="osmatch">LNK Abuse from Accessibility Feature [D0461]</field>
+    <mitre>
+      <id>T1546.008</id>
+    </mitre>
+  </rule>
+
+  <rule id="425420" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Process Keylogger Behavior [D0462].</description>
+    <field name="rulename" type="osmatch">Suspicious Process Keylogger Behavior [D0462]</field>
+    <mitre>
+      <id>T1056.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425430" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible Pass-The-Hash LSASS Access [D0463].</description>
+    <field name="rulename" type="osmatch">Possible Pass-The-Hash LSASS Access [D0463]</field>
+    <mitre>
+      <id>T1550.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="425440" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Non-Interactive Shell Redirect to Named Pipe [D0464].</description>
+    <field name="rulename" type="osmatch">Non-Interactive Shell Redirect to Named Pipe [D0464]</field>
+    <mitre>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="425450" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Process Credential Vault API Usage [D0465].</description>
+    <field name="rulename" type="osmatch">Suspicious Process Credential Vault API Usage [D0465]</field>
+    <mitre>
+      <id>T1555.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="425460" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network Share Creation Through Psexec [D0467].</description>
+    <field name="rulename" type="osmatch">Network Share Creation Through Psexec [D0467]</field>
+    <mitre>
+      <id>T1039</id>
+      <id>T1021.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="425470" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network Share Creation with Excessive Access [D0468].</description>
+    <field name="rulename" type="osmatch">Network Share Creation with Excessive Access [D0468]</field>
+    <mitre>
+      <id>T1039</id>
+      <id>T1021.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="425480" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Default CobaltStrike Named Pipe [D0469].</description>
+    <field name="rulename" type="osmatch">Default CobaltStrike Named Pipe [D0469]</field>
+    <mitre>
+      <id>T1559</id>
+    </mitre>
+  </rule>
+
+  <rule id="425490" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Veritas Backup Exec Exploitation - Windows [D0471].</description>
+    <field name="rulename" type="osmatch">Veritas Backup Exec Exploitation - Windows [D0471]</field>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="425500" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: IIS Downloads Atera Agent [D0472].</description>
+    <field name="rulename" type="osmatch">IIS Downloads Atera Agent [D0472]</field>
+    <mitre>
+      <id>T1190</id>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425510" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Credential Dumping Using comsvcs.dll [D0473].</description>
+    <field name="rulename" type="osmatch">Credential Dumping Using comsvcs.dll [D0473]</field>
+    <mitre>
+      <id>T1003.001</id>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="425520" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Unpopular process made suspicious http query [D0519].</description>
+    <field name="rulename" type="osmatch">Unpopular process made suspicious http query [D0519]</field>
+    <mitre>
+      <id>T1071.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425530" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Desktop Connection from External IP Range [D0522].</description>
+    <field name="rulename" type="osmatch">Remote Desktop Connection from External IP Range [D0522]</field>
+    <mitre>
+      <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425540" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: VNC Connection from Internal IP Range [D0523a].</description>
+    <field name="rulename" type="osmatch">VNC Connection from Internal IP Range [D0523a]</field>
+    <mitre>
+      <id>T1021.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="425550" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: VNC Connection from External IP Range [D0523b].</description>
+    <field name="rulename" type="osmatch">VNC Connection from External IP Range [D0523b]</field>
+    <mitre>
+      <id>T1021.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="425560" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious PowerShell Script - Network [D0524].</description>
+    <field name="rulename" type="osmatch">Suspicious PowerShell Script - Network [D0524]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="425570" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious PowerShell script - SQL Communication [D0525].</description>
+    <field name="rulename" type="osmatch">Suspicious PowerShell script - SQL Communication [D0525]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1213</id>
+    </mitre>
+  </rule>
+
+  <rule id="425580" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Blockchain DNS Resolvers Accessed [D0526].</description>
+    <field name="rulename" type="osmatch">Blockchain DNS Resolvers Accessed [D0526]</field>
+    <mitre>
+      <id>T1008</id>
+    </mitre>
+  </rule>
+
+  <rule id="425590" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: TrickBot handshake protocol detected [D0527].</description>
+    <field name="rulename" type="osmatch">TrickBot handshake protocol detected [D0527]</field>
+    <mitre>
+      <id>T1071.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425600" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: TrickBot module request detected [D0528].</description>
+    <field name="rulename" type="osmatch">TrickBot module request detected [D0528]</field>
+    <mitre>
+      <id>T1071.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425610" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: BITS transfer using PowerShell [D0529].</description>
+    <field name="rulename" type="osmatch">BITS transfer using PowerShell [D0529]</field>
+    <mitre>
+      <id>T1197</id>
+      <id>T1105</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="425620" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: BITS transfer using bitsadmin.exe [D0530].</description>
+    <field name="rulename" type="osmatch">BITS transfer using bitsadmin.exe [D0530]</field>
+    <mitre>
+      <id>T1197</id>
+      <id>T1105</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="425630" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Network Connection from werfault.exe [D0531].</description>
+    <field name="rulename" type="osmatch">Suspicious Network Connection from werfault.exe [D0531]</field>
+    <mitre>
+      <id>T1036</id>
+      <id>T1071.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425640" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible Log4Shell (CVE-2021-44228) Exploitation [D0532a].</description>
+    <field name="rulename" type="osmatch">Possible Log4Shell (CVE-2021-44228) Exploitation [D0532a]</field>
+    <mitre>
+      <id>T1210</id>
+    </mitre>
+  </rule>
+
+  <rule id="425650" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible Log4Shell (CVE-2021-44228) exploitation [D0532b].</description>
+    <field name="rulename" type="osmatch">Possible Log4Shell (CVE-2021-44228) exploitation [D0532b]</field>
+    <mitre>
+      <id>T1210</id>
+    </mitre>
+  </rule>
+
+  <rule id="425660" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Port Forwarding - plink.exe [D0533].</description>
+    <field name="rulename" type="osmatch">Remote Port Forwarding - plink.exe [D0533]</field>
+    <mitre>
+      <id>T1572</id>
+    </mitre>
+  </rule>
+
+  <rule id="425670" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Non-Dropbox Process Communicating with Dropbox API [D0534].</description>
+    <field name="rulename" type="osmatch">Non-Dropbox Process Communicating with Dropbox API [D0534]</field>
+    <mitre>
+      <id>T1020</id>
+    </mitre>
+  </rule>
+
+  <rule id="425680" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Packet Monitor Usage [D0535].</description>
+    <field name="rulename" type="osmatch">Packet Monitor Usage [D0535]</field>
+    <mitre>
+      <id>T1040</id>
+    </mitre>
+  </rule>
+
+  <rule id="425690" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell Credential Vault Dumping [D0701].</description>
+    <field name="rulename" type="osmatch">PowerShell Credential Vault Dumping [D0701]</field>
+    <mitre>
+      <id>T1555.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="425700" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Chrome Browser Pivoting using Remote Debugging [D0702].</description>
+    <field name="rulename" type="osmatch">Chrome Browser Pivoting using Remote Debugging [D0702]</field>
+    <mitre>
+      <id>T1185</id>
+    </mitre>
+  </rule>
+
+  <rule id="425710" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office Application Invoked Script Interpreter [D0807].</description>
+    <field name="rulename" type="osmatch">Microsoft Office Application Invoked Script Interpreter [D0807]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1203</id>
+    </mitre>
+  </rule>
+
+  <rule id="425720" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Uncommon Office Application Invoked Script Interpreter [D0808].</description>
+    <field name="rulename" type="osmatch">Uncommon Office Application Invoked Script Interpreter [D0808]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1203</id>
+    </mitre>
+  </rule>
+
+  <rule id="425730" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office application executed a suspicious macro [D0809].</description>
+    <field name="rulename" type="osmatch">Microsoft Office application executed a suspicious macro [D0809]</field>
+    <mitre>
+      <id>T1059.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="425740" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office Task Scheduler Usage [D0811].</description>
+    <field name="rulename" type="osmatch">Microsoft Office Task Scheduler Usage [D0811]</field>
+    <mitre>
+      <id>T1204.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="425750" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office Suspicious CPL Execution [D0813].</description>
+    <field name="rulename" type="osmatch">Microsoft Office Suspicious CPL Execution [D0813]</field>
+    <mitre>
+      <id>T1203</id>
+    </mitre>
+  </rule>
+
+  <rule id="425760" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Outlook Inbox email body extraction [D0815].</description>
+    <field name="rulename" type="osmatch">Microsoft Outlook Inbox email body extraction [D0815]</field>
+    <mitre>
+      <id>T1552</id>
+    </mitre>
+  </rule>
+
+  <rule id="425770" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Outlook Inbox sender address extraction [D0816].</description>
+    <field name="rulename" type="osmatch">Microsoft Outlook Inbox sender address extraction [D0816]</field>
+    <mitre>
+      <id>T1114.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425780" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office VSTO Add-In Registration [D0817].</description>
+    <field name="rulename" type="osmatch">Microsoft Office VSTO Add-In Registration [D0817]</field>
+    <mitre>
+      <id>T1137.006</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="425790" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office VSTO Add-In Download [D0818].</description>
+    <field name="rulename" type="osmatch">Microsoft Office VSTO Add-In Download [D0818]</field>
+    <mitre>
+      <id>T1137.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="425800" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Office Spawns msdt.exe [D0819].</description>
+    <field name="rulename" type="osmatch">Microsoft Office Spawns msdt.exe [D0819]</field>
+    <mitre>
+      <id>T1203</id>
+    </mitre>
+  </rule>
+
+  <rule id="425810" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Quick Assist incoming connection [D0900].</description>
+    <field name="rulename" type="osmatch">Quick Assist incoming connection [D0900]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425820" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - BeamYourScreen [D0903].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - BeamYourScreen [D0903]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425830" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - LogMeIn [D0904].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - LogMeIn [D0904]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425840" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - AnyPlace Control [D0905].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - AnyPlace Control [D0905]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425850" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - Ammyy Admin [D0906].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - Ammyy Admin [D0906]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425860" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - SupRemo [D0907].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - SupRemo [D0907]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425870" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - RemoteUtilities [D0908].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - RemoteUtilities [D0908]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425880" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - ShowMyPC [D0909].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - ShowMyPC [D0909]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425890" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - Litemanager [D0910].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - Litemanager [D0910]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425900" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - Splashtop [D0911].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - Splashtop [D0911]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425910" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - RemotePC [D0912].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - RemotePC [D0912]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="425920" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell Added Root Certificate [D1000].</description>
+    <field name="rulename" type="osmatch">PowerShell Added Root Certificate [D1000]</field>
+    <mitre>
+      <id>T1553.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="425930" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Service Configuration [D1001].</description>
+    <field name="rulename" type="osmatch">Suspicious Service Configuration [D1001]</field>
+    <mitre>
+      <id>T1543.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="425940" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious PowerShell script - Screen/Keystroke/Window Capture [D1101].</description>
+    <field name="rulename" type="osmatch">Suspicious PowerShell script - Screen/Keystroke/Window Capture [D1101]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1056</id>
+      <id>T1113</id>
+      <id>T1115</id>
+      <id>T1010</id>
+    </mitre>
+  </rule>
+
+  <rule id="425950" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Domain trust discovery [D1102].</description>
+    <field name="rulename" type="osmatch">Domain trust discovery [D1102]</field>
+    <mitre>
+      <id>T1482</id>
+    </mitre>
+  </rule>
+
+  <rule id="425960" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Removable Device Enumeration - LNK [D1103].</description>
+    <field name="rulename" type="osmatch">Suspicious Removable Device Enumeration - LNK [D1103]</field>
+    <mitre>
+      <id>T1091</id>
+    </mitre>
+  </rule>
+
+  <rule id="425970" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious PowerShell Script - Behavior [D1202].</description>
+    <field name="rulename" type="osmatch">Suspicious PowerShell Script - Behavior [D1202]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1027</id>
+    </mitre>
+  </rule>
+
+  <rule id="425980" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Long PowerShell script [D1203].</description>
+    <field name="rulename" type="osmatch">Long PowerShell script [D1203]</field>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="425990" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious PowerShell script - Hiding [D1204].</description>
+    <field name="rulename" type="osmatch">Suspicious PowerShell script - Hiding [D1204]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426000" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Disable logging using auditpol [D1207].</description>
+    <field name="rulename" type="osmatch">Disable logging using auditpol [D1207]</field>
+    <mitre>
+      <id>T1562.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426010" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Defender Disabled Using PowerShell [D1208].</description>
+    <field name="rulename" type="osmatch">Microsoft Defender Disabled Using PowerShell [D1208]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426020" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Loaded Mimikatz Driver [D1301].</description>
+    <field name="rulename" type="osmatch">Loaded Mimikatz Driver [D1301]</field>
+    <mitre>
+      <id>T1543.003</id>
+      <id>T1003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426030" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Loaded Known Vulnerable Driver [D1302].</description>
+    <field name="rulename" type="osmatch">Loaded Known Vulnerable Driver [D1302]</field>
+    <mitre>
+      <id>T1068</id>
+    </mitre>
+  </rule>
+
+  <rule id="426040" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Loaded Driver from Uncommon Location [D1303].</description>
+    <field name="rulename" type="osmatch">Loaded Driver from Uncommon Location [D1303]</field>
+    <mitre>
+      <id>T1068</id>
+    </mitre>
+  </rule>
+
+  <rule id="426050" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Loaded Driver Abused by Wipers [D1305].</description>
+    <field name="rulename" type="osmatch">Loaded Driver Abused by Wipers [D1305]</field>
+    <mitre>
+      <id>T1485</id>
+      <id>T1561</id>
+    </mitre>
+  </rule>
+
+  <rule id="426060" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WinDivert Driver Loaded [D1307].</description>
+    <field name="rulename" type="osmatch">WinDivert Driver Loaded [D1307]</field>
+    <mitre>
+      <id>T1040</id>
+    </mitre>
+  </rule>
+
+  <rule id="426070" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Persistence Installation - IFEO SilentProcessExit registry key altered [E0101].</description>
+    <field name="rulename" type="osmatch">Potential Persistence Installation - IFEO SilentProcessExit registry key altered [E0101]</field>
+    <mitre>
+      <id>T1546.012</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="426080" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: LNK Scheduled Task Persistence [E0102].</description>
+    <field name="rulename" type="osmatch">LNK Scheduled Task Persistence [E0102]</field>
+    <mitre>
+      <id>T1053.005</id>
+      <id>T1204.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426090" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Credential Dumping - IFEO SilentProcessExit registry key set for Lsass.exe [E0201].</description>
+    <field name="rulename" type="osmatch">Potential Credential Dumping - IFEO SilentProcessExit registry key set for Lsass.exe [E0201]</field>
+    <mitre>
+      <id>T1003.001</id>
+      <id>T1546.012</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="426100" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: CLR Remote Assembly Load via COM Server Registration [E0202].</description>
+    <field name="rulename" type="osmatch">CLR Remote Assembly Load via COM Server Registration [E0202]</field>
+    <mitre>
+      <id>T1559.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="426110" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: High-risk process has written to the Recycle Bin folder [E0301].</description>
+    <field name="rulename" type="osmatch">High-risk process has written to the Recycle Bin folder [E0301]</field>
+    <mitre>
+      <id>T1564</id>
+      <id>T1074.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426120" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious process (low reputation) has written to the Recycle Bin folder [E0302].</description>
+    <field name="rulename" type="osmatch">Suspicious process (low reputation) has written to the Recycle Bin folder [E0302]</field>
+    <mitre>
+      <id>T1564</id>
+      <id>T1074.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426130" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Unpopular process has written to the Recycle Bin folder [E0303].</description>
+    <field name="rulename" type="osmatch">Unpopular process has written to the Recycle Bin folder [E0303]</field>
+    <mitre>
+      <id>T1564</id>
+      <id>T1074.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426140" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Has Written a Suspicious File to Recycle Bin Folder [E0304].</description>
+    <field name="rulename" type="osmatch">Process Has Written a Suspicious File to Recycle Bin Folder [E0304]</field>
+    <mitre>
+      <id>T1564</id>
+      <id>T1074.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426150" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Credential Dumping - lsass*.dmp file has been written to disk [E0305].</description>
+    <field name="rulename" type="osmatch">Potential Credential Dumping - lsass*.dmp file has been written to disk [E0305]</field>
+    <mitre>
+      <id>T1003.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426160" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Email Collection: Local Email Collection via PowerShell (copying) [E0306].</description>
+    <field name="rulename" type="osmatch">Potential Email Collection: Local Email Collection via PowerShell (copying) [E0306]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1114.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426170" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Collection of data from local system via WMI file classes [E0307].</description>
+    <field name="rulename" type="osmatch">Potential Collection of data from local system via WMI file classes [E0307]</field>
+    <mitre>
+      <id>T1047</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="426180" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Email Collection: Local Email Collection via WMI file classes [E0308].</description>
+    <field name="rulename" type="osmatch">Potential Email Collection: Local Email Collection via WMI file classes [E0308]</field>
+    <mitre>
+      <id>T1047</id>
+      <id>T1005</id>
+      <id>T1114.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426190" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Collection of data from local system via PowerShell (copying) [E0309].</description>
+    <field name="rulename" type="osmatch">Potential Collection of data from local system via PowerShell (copying) [E0309]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="426200" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Memory Dumping Tool Dropped (DumpIt/WinPMem) [E0310].</description>
+    <field name="rulename" type="osmatch">Memory Dumping Tool Dropped (DumpIt/WinPMem) [E0310]</field>
+    <mitre>
+      <id>T1003.001</id>
+      <id>T1003.002</id>
+      <id>T1003.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="426210" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process with Recycle Bin path in command line [E0401].</description>
+    <field name="rulename" type="osmatch">Process with Recycle Bin path in command line [E0401]</field>
+    <mitre>
+      <id>T1564</id>
+    </mitre>
+  </rule>
+
+  <rule id="426220" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process loaded DLL from Recycle Bin folder [E0402].</description>
+    <field name="rulename" type="osmatch">Process loaded DLL from Recycle Bin folder [E0402]</field>
+    <mitre>
+      <id>T1564</id>
+    </mitre>
+  </rule>
+
+  <rule id="426230" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Spawned by WMI Script Consumer [E0403].</description>
+    <field name="rulename" type="osmatch">Process Spawned by WMI Script Consumer [E0403]</field>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="426240" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Risky Process Spawned by WMI Script Consumer [E0404].</description>
+    <field name="rulename" type="osmatch">Risky Process Spawned by WMI Script Consumer [E0404]</field>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="426250" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Process Spawned by WMI Script Consumer [E0405].</description>
+    <field name="rulename" type="osmatch">Suspicious Process Spawned by WMI Script Consumer [E0405]</field>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="426260" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: LolBin Process Spawned by WMI Script Consumer [E0406].</description>
+    <field name="rulename" type="osmatch">LolBin Process Spawned by WMI Script Consumer [E0406]</field>
+    <mitre>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="426270" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Python Download Cradle Execution [E0407].</description>
+    <field name="rulename" type="osmatch">Python Download Cradle Execution [E0407]</field>
+    <mitre>
+      <id>T1059.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="426280" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Lateral File Transfer via Copy/Move Command [E0408].</description>
+    <field name="rulename" type="osmatch">Suspicious Lateral File Transfer via Copy/Move Command [E0408]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1074.001</id>
+      <id>T1074.002</id>
+      <id>T1059.003</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="426290" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Lateral File Transfer via Copy LoLBin [E0409].</description>
+    <field name="rulename" type="osmatch">Suspicious Lateral File Transfer via Copy LoLBin [E0409]</field>
+    <mitre>
+      <id>T1074.001</id>
+      <id>T1074.002</id>
+      <id>T1570</id>
+      <id>T1021.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426300" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Dism.exe execution from a suspicious location [E0410].</description>
+    <field name="rulename" type="osmatch">Dism.exe execution from a suspicious location [E0410]</field>
+    <mitre>
+      <id>T1036.005</id>
+      <id>T1574.001</id>
+      <id>T1574.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426310" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Dism.exe suspicious child process [E0411].</description>
+    <field name="rulename" type="osmatch">Dism.exe suspicious child process [E0411]</field>
+    <mitre>
+      <id>T1055</id>
+      <id>T1574.001</id>
+      <id>T1574.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426320" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Installutil application whitelisting bypass [E0412].</description>
+    <field name="rulename" type="osmatch">Installutil application whitelisting bypass [E0412]</field>
+    <mitre>
+      <id>T1218.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="426330" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Regasm.exe suspicious child process [E0413].</description>
+    <field name="rulename" type="osmatch">Regasm.exe suspicious child process [E0413]</field>
+    <mitre>
+      <id>T1218.009</id>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="426340" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Searchprotocolhost.exe suspicious child processes [E0414].</description>
+    <field name="rulename" type="osmatch">Searchprotocolhost.exe suspicious child processes [E0414]</field>
+    <mitre>
+      <id>T1036.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="426350" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious colorcpl.exe parent execution [E0415].</description>
+    <field name="rulename" type="osmatch">Suspicious colorcpl.exe parent execution [E0415]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="426360" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious colorcpl.exe child execution [E0416].</description>
+    <field name="rulename" type="osmatch">Suspicious colorcpl.exe child execution [E0416]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="426370" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious execution of search indexer [E0417].</description>
+    <field name="rulename" type="osmatch">Suspicious execution of search indexer [E0417]</field>
+    <mitre>
+      <id>T1036.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="426380" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: DismCore.dll loaded from a suspicious location [E0418].</description>
+    <field name="rulename" type="osmatch">DismCore.dll loaded from a suspicious location [E0418]</field>
+    <mitre>
+      <id>T1036.005</id>
+      <id>T1574.001</id>
+      <id>T1574.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426390" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Lateral File Removal [E0419].</description>
+    <field name="rulename" type="osmatch">Suspicious Lateral File Removal [E0419]</field>
+    <mitre>
+      <id>T1070.004</id>
+      <id>T1021.002</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426400" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious LoLBaS Execution: Renamed LoLBaS execution [E0420].</description>
+    <field name="rulename" type="osmatch">Suspicious LoLBaS Execution: Renamed LoLBaS execution [E0420]</field>
+    <mitre>
+      <id>T1036.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426410" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Echo Redirection Over SMB Shares [E0421].</description>
+    <field name="rulename" type="osmatch">Echo Redirection Over SMB Shares [E0421]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426420" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process execution from suspicious location (execution flow hijacking) [E0422].</description>
+    <field name="rulename" type="osmatch">Process execution from suspicious location (execution flow hijacking) [E0422]</field>
+    <mitre>
+      <id>T1036.005</id>
+      <id>T1574.001</id>
+      <id>T1574.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426430" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential China Chopper Web Shell [E0423].</description>
+    <field name="rulename" type="osmatch">Potential China Chopper Web Shell [E0423]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426440" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Exchange PSSnapin Loaded via Add-PSSnapin (cmdline) [E0424].</description>
+    <field name="rulename" type="osmatch">Exchange PSSnapin Loaded via Add-PSSnapin (cmdline) [E0424]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426450" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Exchange Unified Messaging Service Suspicious Child Process [E0425].</description>
+    <field name="rulename" type="osmatch">Exchange Unified Messaging Service Suspicious Child Process [E0425]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426460" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Exchange IIS Process File Drops [E0426].</description>
+    <field name="rulename" type="osmatch">Suspicious Exchange IIS Process File Drops [E0426]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426470" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Exchange (w3wp.exe) Child Process [E0427].</description>
+    <field name="rulename" type="osmatch">Suspicious Exchange (w3wp.exe) Child Process [E0427]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426480" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Exchange IIS Process File Operations [E0428].</description>
+    <field name="rulename" type="osmatch">Suspicious Exchange IIS Process File Operations [E0428]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426490" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Unified Messaging Service File Operations [E0429a].</description>
+    <field name="rulename" type="osmatch">Suspicious Unified Messaging Service File Operations [E0429a]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426500" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Unified Messaging Service File Operations [E0429b].</description>
+    <field name="rulename" type="osmatch">Suspicious Unified Messaging Service File Operations [E0429b]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426510" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: VBScript Writing MZ Header to Disk [E0430].</description>
+    <field name="rulename" type="osmatch">VBScript Writing MZ Header to Disk [E0430]</field>
+    <mitre>
+      <id>T1059.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="426520" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Echo Redirection Over SMB to Suspicious File [E0431].</description>
+    <field name="rulename" type="osmatch">Echo Redirection Over SMB to Suspicious File [E0431]</field>
+    <mitre>
+      <id>T1059.003</id>
+      <id>T1021.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426530" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Lateral Type Command Usage Over SMB Share [E0432].</description>
+    <field name="rulename" type="osmatch">Lateral Type Command Usage Over SMB Share [E0432]</field>
+    <mitre>
+      <id>T1059.003</id>
+      <id>T1021.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426540" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Lateral Type Command Usage Over SMB Share [E0433].</description>
+    <field name="rulename" type="osmatch">Suspicious Lateral Type Command Usage Over SMB Share [E0433]</field>
+    <mitre>
+      <id>T1059.003</id>
+      <id>T1021.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426550" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious LoLBaS execution: Cmstp.exe (Execute|AWL bypass|Local .INF) [E0434].</description>
+    <field name="rulename" type="osmatch">Suspicious LoLBaS execution: Cmstp.exe (Execute|AWL bypass|Local .INF) [E0434]</field>
+    <mitre>
+      <id>T1218.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426560" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious LoLBaS execution: Cmstp.exe (Execute|AWL bypass|Remote .INF) [E0435].</description>
+    <field name="rulename" type="osmatch">Suspicious LoLBaS execution: Cmstp.exe (Execute|AWL bypass|Remote .INF) [E0435]</field>
+    <mitre>
+      <id>T1218.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426570" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious LoLBaS Execution: Control.exe loading DLL from ADS (Alternate Data Streams) [E0437].</description>
+    <field name="rulename" type="osmatch">Suspicious LoLBaS Execution: Control.exe loading DLL from ADS (Alternate Data Streams) [E0437]</field>
+    <mitre>
+      <id>T1218.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="426580" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious DLL loaded from Alternate Data Stream [E0438].</description>
+    <field name="rulename" type="osmatch">Suspicious DLL loaded from Alternate Data Stream [E0438]</field>
+    <mitre>
+      <id>T1218.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="426590" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious LoLBaS execution: Certutil.exe (Download|Alternate Data Streams) [E0441].</description>
+    <field name="rulename" type="osmatch">Suspicious LoLBaS execution: Certutil.exe (Download|Alternate Data Streams) [E0441]</field>
+    <mitre>
+      <id>T1218.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="426600" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Single Character .Bat File Executed [E0442a].</description>
+    <field name="rulename" type="osmatch">Single Character .Bat File Executed [E0442a]</field>
+    <mitre>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426610" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Single Character .Vbs File Executed [E0442b].</description>
+    <field name="rulename" type="osmatch">Single Character .Vbs File Executed [E0442b]</field>
+    <mitre>
+      <id>T1059.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="426620" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: BAT Script Created New (Local/Domain) Administrator Account [E0443].</description>
+    <field name="rulename" type="osmatch">BAT Script Created New (Local/Domain) Administrator Account [E0443]</field>
+    <mitre>
+      <id>T1059.003</id>
+      <id>T1136.001</id>
+      <id>T1098</id>
+    </mitre>
+  </rule>
+
+  <rule id="426630" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Apache ActiveMQ (CVE-2023-46604) Post-Exploitation (Cmd/cURL) [E0444].</description>
+    <field name="rulename" type="osmatch">Apache ActiveMQ (CVE-2023-46604) Post-Exploitation (Cmd/cURL) [E0444]</field>
+    <mitre>
+      <id>T1059.003</id>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="426640" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Apache ActiveMQ (CVE-2023-46604) Suspicious Child Process [E0445].</description>
+    <field name="rulename" type="osmatch">Apache ActiveMQ (CVE-2023-46604) Suspicious Child Process [E0445]</field>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="426650" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive compression via PowerShells Compress-Archive [E0446].</description>
+    <field name="rulename" type="osmatch">Archive compression via PowerShells Compress-Archive [E0446]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1560</id>
+    </mitre>
+  </rule>
+
+  <rule id="426660" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive compression using C#.NET methods via PowerShell [E0447].</description>
+    <field name="rulename" type="osmatch">Archive compression using C#.NET methods via PowerShell [E0447]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1560</id>
+      <id>T1027</id>
+    </mitre>
+  </rule>
+
+  <rule id="426670" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI Win32_Process derivation invocation via PowerShell [E0448].</description>
+    <field name="rulename" type="osmatch">WMI Win32_Process derivation invocation via PowerShell [E0448]</field>
+    <mitre>
+      <id>T1047</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426680" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Atlassian Confluence (CVE-2023-22518) Exploitation [E0449].</description>
+    <field name="rulename" type="osmatch">Atlassian Confluence (CVE-2023-22518) Exploitation [E0449]</field>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="426690" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Service Control command has been executed (sc.exe) [E0450].</description>
+    <field name="rulename" type="osmatch">Remote Service Control command has been executed (sc.exe) [E0450]</field>
+    <mitre>
+      <id>T1543.003</id>
+      <id>T1569.002</id>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426700" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Service Stopped or Started (sc.exe) [E0451].</description>
+    <field name="rulename" type="osmatch">Remote Service Stopped or Started (sc.exe) [E0451]</field>
+    <mitre>
+      <id>T1569.002</id>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426710" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Defense Evasion - Security service has been remotely interfered with (sc.exe start,stop) [E0452].</description>
+    <field name="rulename" type="osmatch">Potential Defense Evasion - Security service has been remotely interfered with (sc.exe start,stop) [E0452]</field>
+    <mitre>
+      <id>T1569.002</id>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426720" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Defense Evasion - Security service has been interfered with (sc.exe/net.exe start,stop) [E0453].</description>
+    <field name="rulename" type="osmatch">Potential Defense Evasion - Security service has been interfered with (sc.exe/net.exe start,stop) [E0453]</field>
+    <mitre>
+      <id>T1569.002</id>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="426730" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Atlassian Confluence Exploitation (ITW) [E0454].</description>
+    <field name="rulename" type="osmatch">Atlassian Confluence Exploitation (ITW) [E0454]</field>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="426740" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: AMSI VBScript Parsing Credentials via RegEx [E0457].</description>
+    <field name="rulename" type="osmatch">AMSI VBScript Parsing Credentials via RegEx [E0457]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1552</id>
+    </mitre>
+  </rule>
+
+  <rule id="426750" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Tomcat Post-Exploitation (LoLBin via PS/CMD) [E0458].</description>
+    <field name="rulename" type="osmatch">Potential Tomcat Post-Exploitation (LoLBin via PS/CMD) [E0458]</field>
+    <mitre>
+      <id>T1190</id>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426760" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed RClone.exe Executed [E0459].</description>
+    <field name="rulename" type="osmatch">Renamed RClone.exe Executed [E0459]</field>
+    <mitre>
+      <id>T1567</id>
+      <id>T1036</id>
+    </mitre>
+  </rule>
+
+  <rule id="426770" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Qlik Sense Post-Exploitation Lineage [E0460].</description>
+    <field name="rulename" type="osmatch">Potential Qlik Sense Post-Exploitation Lineage [E0460]</field>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="426780" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Java Runtime exploitation [E0461].</description>
+    <field name="rulename" type="osmatch">Potential Java Runtime exploitation [E0461]</field>
+    <mitre>
+      <id>T1203</id>
+    </mitre>
+  </rule>
+
+  <rule id="426790" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Java Runtime executing suspicious script/command interpreter [E0462].</description>
+    <field name="rulename" type="osmatch">Java Runtime executing suspicious script/command interpreter [E0462]</field>
+    <mitre>
+      <id>T1203</id>
+      <id>T1059</id>
+    </mitre>
+  </rule>
+
+  <rule id="426800" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Nvidia Signed module was executed [E0463].</description>
+    <field name="rulename" type="osmatch">Suspicious Nvidia Signed module was executed [E0463]</field>
+    <mitre>
+      <id>T1553.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426810" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Nvidia Signed module was dropped [E0464].</description>
+    <field name="rulename" type="osmatch">Suspicious Nvidia Signed module was dropped [E0464]</field>
+    <mitre>
+      <id>T1553.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426820" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Nvidia Signed module was loaded [E0465].</description>
+    <field name="rulename" type="osmatch">Suspicious Nvidia Signed module was loaded [E0465]</field>
+    <mitre>
+      <id>T1553.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="426830" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Mavinject.exe usage [E0466].</description>
+    <field name="rulename" type="osmatch">Suspicious Mavinject.exe usage [E0466]</field>
+    <mitre>
+      <id>T1218.013</id>
+    </mitre>
+  </rule>
+
+  <rule id="426840" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Cmd.exe Invoking Suspicious Process via Start [E0467].</description>
+    <field name="rulename" type="osmatch">Cmd.exe Invoking Suspicious Process via Start [E0467]</field>
+    <mitre>
+      <id>T1059</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="426850" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: W3wp.exe Drops Suspicious Module [E0468].</description>
+    <field name="rulename" type="osmatch">W3wp.exe Drops Suspicious Module [E0468]</field>
+    <mitre>
+      <id>T1505.003</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="426860" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Tomcat Post-Exploitation (LoLBin) [E0469].</description>
+    <field name="rulename" type="osmatch">Potential Tomcat Post-Exploitation (LoLBin) [E0469]</field>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="426870" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Explorer.exe Loading Suspicious .Net Assembly [E0472].</description>
+    <field name="rulename" type="osmatch">Explorer.exe Loading Suspicious .Net Assembly [E0472]</field>
+    <mitre>
+      <id>T1620</id>
+    </mitre>
+  </rule>
+
+  <rule id="426880" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Loading .Net CLR (CS execute-assembly) [E0473a].</description>
+    <field name="rulename" type="osmatch">Process Loading .Net CLR (CS execute-assembly) [E0473a]</field>
+    <mitre>
+      <id>T1620</id>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="426890" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Unusual Process Loading .Net CLR (CS execute-assembly) [E0473b].</description>
+    <field name="rulename" type="osmatch">Unusual Process Loading .Net CLR (CS execute-assembly) [E0473b]</field>
+    <mitre>
+      <id>T1620</id>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="426900" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Process Loading .Net CLR (CS execute-assembly) [E0473c].</description>
+    <field name="rulename" type="osmatch">Suspicious Process Loading .Net CLR (CS execute-assembly) [E0473c]</field>
+    <mitre>
+      <id>T1620</id>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="426910" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Compromised Process Loading .Net CLR DLL [E0473].</description>
+    <field name="rulename" type="osmatch">Suspicious Compromised Process Loading .Net CLR DLL [E0473]</field>
+    <mitre>
+      <id>T1620</id>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="426920" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential SharePoint Post-Exploitation (Cmd/PowerShell) [E0474].</description>
+    <field name="rulename" type="osmatch">Potential SharePoint Post-Exploitation (Cmd/PowerShell) [E0474]</field>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="426930" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential SharePoint Post-Exploitation (LoLBin) [E0475].</description>
+    <field name="rulename" type="osmatch">Potential SharePoint Post-Exploitation (LoLBin) [E0475]</field>
+    <mitre>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="426940" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Memory Dumping Tool Executed (DumpIt/WinPMem) [E0476].</description>
+    <field name="rulename" type="osmatch">Memory Dumping Tool Executed (DumpIt/WinPMem) [E0476]</field>
+    <mitre>
+      <id>T1003.001</id>
+      <id>T1003.002</id>
+      <id>T1003.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="426950" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Memory Dumping Driver Loaded (DumpIt/WinPMem) [E0477].</description>
+    <field name="rulename" type="osmatch">Memory Dumping Driver Loaded (DumpIt/WinPMem) [E0477]</field>
+    <mitre>
+      <id>T1003.001</id>
+      <id>T1003.002</id>
+      <id>T1003.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="426960" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Non-browser process makes HTTP request to a popular Web Service [E0501].</description>
+    <field name="rulename" type="osmatch">Non-browser process makes HTTP request to a popular Web Service [E0501]</field>
+    <mitre>
+      <id>T1102</id>
+    </mitre>
+  </rule>
+
+  <rule id="426970" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Unpopular process makes HTTP request to a popular Web Service [E0502].</description>
+    <field name="rulename" type="osmatch">Unpopular process makes HTTP request to a popular Web Service [E0502]</field>
+    <mitre>
+      <id>T1102</id>
+    </mitre>
+  </rule>
+
+  <rule id="426980" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: High-risk process makes HTTP request to a popular Web Service [E0503].</description>
+    <field name="rulename" type="osmatch">High-risk process makes HTTP request to a popular Web Service [E0503]</field>
+    <mitre>
+      <id>T1102</id>
+    </mitre>
+  </rule>
+
+  <rule id="426990" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Non-browser process makes HTTP request to a PasteBin-like site [E0504].</description>
+    <field name="rulename" type="osmatch">Non-browser process makes HTTP request to a PasteBin-like site [E0504]</field>
+    <mitre>
+      <id>T1102.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427000" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Unpopular process makes HTTP request to a PasteBin-like site [E0505].</description>
+    <field name="rulename" type="osmatch">Unpopular process makes HTTP request to a PasteBin-like site [E0505]</field>
+    <mitre>
+      <id>T1102.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427010" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: High-risk process makes HTTP request to a PasteBin-like site [E0506].</description>
+    <field name="rulename" type="osmatch">High-risk process makes HTTP request to a PasteBin-like site [E0506]</field>
+    <mitre>
+      <id>T1102.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427020" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Protocol Mismatch - FTP Over Non-Standard Port [E0509].</description>
+    <field name="rulename" type="osmatch">Protocol Mismatch - FTP Over Non-Standard Port [E0509]</field>
+    <mitre>
+      <id>T1571</id>
+      <id>T1071.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="427030" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process communicating over Suspicious Protocol - detected TOR communication [E0510].</description>
+    <field name="rulename" type="osmatch">Process communicating over Suspicious Protocol - detected TOR communication [E0510]</field>
+    <mitre>
+      <id>T1573.002</id>
+      <id>T1090.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="427040" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process communicating over Suspicious Protocol - detected BitTorrent communication [E0512].</description>
+    <field name="rulename" type="osmatch">Process communicating over Suspicious Protocol - detected BitTorrent communication [E0512]</field>
+    <mitre>
+      <id>T1189</id>
+      <id>T1090.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="427050" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process communicating over Suspicious Protocol - detected IRC communication [E0514].</description>
+    <field name="rulename" type="osmatch">Process communicating over Suspicious Protocol - detected IRC communication [E0514]</field>
+    <mitre>
+      <id>T1090.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="427060" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Protocol Mismatch - detected RDP communication over non-standard port [E0517].</description>
+    <field name="rulename" type="osmatch">Protocol Mismatch - detected RDP communication over non-standard port [E0517]</field>
+    <mitre>
+      <id>T1571</id>
+      <id>T1021.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427070" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Protocol Mismatch - Internal Host, Non-Standard HTTP Port, Unpopular Process [E0520].</description>
+    <field name="rulename" type="osmatch">Protocol Mismatch - Internal Host, Non-Standard HTTP Port, Unpopular Process [E0520]</field>
+    <mitre>
+      <id>T1571</id>
+    </mitre>
+  </rule>
+
+  <rule id="427080" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Internal SSL Comms Over Non-Standard Port, Unpopular Process [E0521].</description>
+    <field name="rulename" type="osmatch">Internal SSL Comms Over Non-Standard Port, Unpopular Process [E0521]</field>
+    <mitre>
+      <id>T1571</id>
+    </mitre>
+  </rule>
+
+  <rule id="427090" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Protocol Mismatch - External Host, Non-Standard HTTP Port, Unpopular Process [E0522].</description>
+    <field name="rulename" type="osmatch">Protocol Mismatch - External Host, Non-Standard HTTP Port, Unpopular Process [E0522]</field>
+    <mitre>
+      <id>T1571</id>
+    </mitre>
+  </rule>
+
+  <rule id="427100" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: External SSL Comms Over Non-Standard Port, Unpopular Process [E0523].</description>
+    <field name="rulename" type="osmatch">External SSL Comms Over Non-Standard Port, Unpopular Process [E0523]</field>
+    <mitre>
+      <id>T1571</id>
+    </mitre>
+  </rule>
+
+  <rule id="427110" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Protocol Mismatch - detected VNC communication over non-standard port [E0524].</description>
+    <field name="rulename" type="osmatch">Protocol Mismatch - detected VNC communication over non-standard port [E0524]</field>
+    <mitre>
+      <id>T1571</id>
+    </mitre>
+  </rule>
+
+  <rule id="427120" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potentially Suspicious VNC Communication [E0525].</description>
+    <field name="rulename" type="osmatch">Potentially Suspicious VNC Communication [E0525]</field>
+    <mitre>
+      <id>T1021.005</id>
+      <id>T1573.002</id>
+      <id>T1090.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="427130" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Protocol Mismatch - detected SMTP communication over non-standard port [E0526].</description>
+    <field name="rulename" type="osmatch">Protocol Mismatch - detected SMTP communication over non-standard port [E0526]</field>
+    <mitre>
+      <id>T1571</id>
+      <id>T1071.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="427140" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process communicating over Suspicious Protocol - SMTP communication, unpopular process [E0527].</description>
+    <field name="rulename" type="osmatch">Process communicating over Suspicious Protocol - SMTP communication, unpopular process [E0527]</field>
+    <mitre>
+      <id>T1071.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="427150" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Protocol Mismatch - detected SSH communication over non-standard port [E0528].</description>
+    <field name="rulename" type="osmatch">Protocol Mismatch - detected SSH communication over non-standard port [E0528]</field>
+    <mitre>
+      <id>T1571</id>
+    </mitre>
+  </rule>
+
+  <rule id="427160" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: External SSH Connection [E0529].</description>
+    <field name="rulename" type="osmatch">External SSH Connection [E0529]</field>
+    <mitre>
+      <id>T1573.002</id>
+      <id>T1090.003</id>
+      <id>T1021.004</id>
+      <id>T1078</id>
+    </mitre>
+  </rule>
+
+  <rule id="427170" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Internal SSH Connection [E0531].</description>
+    <field name="rulename" type="osmatch">Internal SSH Connection [E0531]</field>
+    <mitre>
+      <id>T1573.002</id>
+      <id>T1090.003</id>
+      <id>T1021.004</id>
+      <id>T1078</id>
+    </mitre>
+  </rule>
+
+  <rule id="427180" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process communicating over Suspicious Protocol - detected IMAP communication [E0533].</description>
+    <field name="rulename" type="osmatch">Process communicating over Suspicious Protocol - detected IMAP communication [E0533]</field>
+    <mitre>
+      <id>T1071.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="427190" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process communicating over Suspicious Protocol - detected POP3 communication [E0534].</description>
+    <field name="rulename" type="osmatch">Process communicating over Suspicious Protocol - detected POP3 communication [E0534]</field>
+    <mitre>
+      <id>T1071.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="427200" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process communicating over Suspicious Protocol - detected SIP communication [E0537].</description>
+    <field name="rulename" type="osmatch">Process communicating over Suspicious Protocol - detected SIP communication [E0537]</field>
+    <mitre>
+      <id>T1553.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="427210" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Dism.exe network activity [E0540].</description>
+    <field name="rulename" type="osmatch">Dism.exe network activity [E0540]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="427220" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious network connection from a quiet process [E0541].</description>
+    <field name="rulename" type="osmatch">Suspicious network connection from a quiet process [E0541]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="427230" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious LoLBin execution: AppInstaller.exe suspicious network connection (Download) [E0542].</description>
+    <field name="rulename" type="osmatch">Suspicious LoLBin execution: AppInstaller.exe suspicious network connection (Download) [E0542]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="427240" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious LoLBin execution: AppInstaller.exe - ms-appinstaller cmdline (Download) [E0543].</description>
+    <field name="rulename" type="osmatch">Suspicious LoLBin execution: AppInstaller.exe - ms-appinstaller cmdline (Download) [E0543]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="427250" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious LoLBin execution: CertReq.exe (Download|Upload) [E0544].</description>
+    <field name="rulename" type="osmatch">Suspicious LoLBin execution: CertReq.exe (Download|Upload) [E0544]</field>
+    <mitre>
+      <id>T1218.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="427260" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Exfiltration Attempt - Mounting Cloud Drive via Net Use command [E0550].</description>
+    <field name="rulename" type="osmatch">Potential Exfiltration Attempt - Mounting Cloud Drive via Net Use command [E0550]</field>
+    <mitre>
+      <id>T1567.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="427270" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Interactive (Echo Open Piped) FTP via Web Server [E0551].</description>
+    <field name="rulename" type="osmatch">Interactive (Echo Open Piped) FTP via Web Server [E0551]</field>
+    <mitre>
+      <id>T1190</id>
+      <id>T1071.002</id>
+      <id>T1570</id>
+      <id>T1083</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="427280" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Anonymous File-Sharing Site Requested by Non-Browser [E0552].</description>
+    <field name="rulename" type="osmatch">Anonymous File-Sharing Site Requested by Non-Browser [E0552]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1567.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="427290" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (Arc) encrypting files [E0601].</description>
+    <field name="rulename" type="osmatch">Archive Utility (Arc) encrypting files [E0601]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="427300" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (Pea) encrypting files [E0602].</description>
+    <field name="rulename" type="osmatch">Archive Utility (Pea) encrypting files [E0602]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="427310" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (PeaZip) encrypting files [E0603].</description>
+    <field name="rulename" type="osmatch">Archive Utility (PeaZip) encrypting files [E0603]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="427320" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (PKZIP) encrypting and deleting files [E0604].</description>
+    <field name="rulename" type="osmatch">Archive Utility (PKZIP) encrypting and deleting files [E0604]</field>
+    <mitre>
+      <id>T1486</id>
+      <id>T1560.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427330" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (PACOMP) encrypting files [E0605].</description>
+    <field name="rulename" type="osmatch">Archive Utility (PACOMP) encrypting files [E0605]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="427340" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (WinAce) encrypting files [E0606].</description>
+    <field name="rulename" type="osmatch">Archive Utility (WinAce) encrypting files [E0606]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="427350" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (WinZip) encrypting files [E0607].</description>
+    <field name="rulename" type="osmatch">Archive Utility (WinZip) encrypting files [E0607]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="427360" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (ZPAQ) encrypting files [E0608].</description>
+    <field name="rulename" type="osmatch">Archive Utility (ZPAQ) encrypting files [E0608]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="427370" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (B1) encrypting files [E0609].</description>
+    <field name="rulename" type="osmatch">Archive Utility (B1) encrypting files [E0609]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="427380" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (PKZIP) encrypting files [E0610].</description>
+    <field name="rulename" type="osmatch">Archive Utility (PKZIP) encrypting files [E0610]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="427390" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive related encryption utility (PACRYPT) encrypting files [E0611].</description>
+    <field name="rulename" type="osmatch">Archive related encryption utility (PACRYPT) encrypting files [E0611]</field>
+    <mitre>
+      <id>T1486</id>
+      <id>T1560.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427400" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (7Zip) encrypting and deleting files [E0612].</description>
+    <field name="rulename" type="osmatch">Archive Utility (7Zip) encrypting and deleting files [E0612]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="427410" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (7Zip) encrypting files [E0613].</description>
+    <field name="rulename" type="osmatch">Archive Utility (7Zip) encrypting files [E0613]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="427420" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Lateral Movement - Remote Scheduled Task Created (schtasks.exe) [E0901].</description>
+    <field name="rulename" type="osmatch">Potential Lateral Movement - Remote Scheduled Task Created (schtasks.exe) [E0901]</field>
+    <mitre>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="427430" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Scheduled Task ComObject Created via PowerShell [E0902].</description>
+    <field name="rulename" type="osmatch">Scheduled Task ComObject Created via PowerShell [E0902]</field>
+    <mitre>
+      <id>T1053.005</id>
+      <id>T1059.001</id>
+      <id>T1559.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427440" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Lateral Movement - Remote WINRS activity detected [E0903].</description>
+    <field name="rulename" type="osmatch">Potential Lateral Movement - Remote WINRS activity detected [E0903]</field>
+    <mitre>
+      <id>T1021.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="427450" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed Remote Monitoring &amp; Management Tool [E0904].</description>
+    <field name="rulename" type="osmatch">Renamed Remote Monitoring &amp; Management Tool [E0904]</field>
+    <mitre>
+      <id>T1219</id>
+      <id>T1036</id>
+    </mitre>
+  </rule>
+
+  <rule id="427460" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed Remote Monitoring &amp; Management Tool Dropped [E0905].</description>
+    <field name="rulename" type="osmatch">Renamed Remote Monitoring &amp; Management Tool Dropped [E0905]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1219</id>
+      <id>T1036</id>
+    </mitre>
+  </rule>
+
+  <rule id="427470" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PsExec Remote Execution (Source Details) [E0906].</description>
+    <field name="rulename" type="osmatch">PsExec Remote Execution (Source Details) [E0906]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="427480" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PAExec Remote Execution (Source Details) [E0907].</description>
+    <field name="rulename" type="osmatch">PAExec Remote Execution (Source Details) [E0907]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="427490" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User Added to Sensitive AD Group [E1000].</description>
+    <field name="rulename" type="osmatch">User Added to Sensitive AD Group [E1000]</field>
+    <mitre>
+      <id>T1098</id>
+    </mitre>
+  </rule>
+
+  <rule id="427500" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: SDelete usage detected [E1001].</description>
+    <field name="rulename" type="osmatch">SDelete usage detected [E1001]</field>
+    <mitre>
+      <id>T1070.004</id>
+      <id>T1485</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="427510" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (PKZIP) shredding (secure deleting) files [E1002].</description>
+    <field name="rulename" type="osmatch">Archive Utility (PKZIP) shredding (secure deleting) files [E1002]</field>
+    <mitre>
+      <id>T1070.004</id>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="427520" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Utility (PeaUtils) SDeleting (secure deleting) files [E1003].</description>
+    <field name="rulename" type="osmatch">Archive Utility (PeaUtils) SDeleting (secure deleting) files [E1003]</field>
+    <mitre>
+      <id>T1070.004</id>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="427530" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process reading sensitive files - FTP-based Credential Stores [E1102].</description>
+    <field name="rulename" type="osmatch">Process reading sensitive files - FTP-based Credential Stores [E1102]</field>
+    <mitre>
+      <id>T1555</id>
+      <id>T1552.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="427540" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process reading sensitive files - Windows Credential Stores [E1103].</description>
+    <field name="rulename" type="osmatch">Process reading sensitive files - Windows Credential Stores [E1103]</field>
+    <mitre>
+      <id>T1555</id>
+      <id>T1552.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="427550" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process reading sensitive files - Credential Manager configs [E1104].</description>
+    <field name="rulename" type="osmatch">Process reading sensitive files - Credential Manager configs [E1104]</field>
+    <mitre>
+      <id>T1555</id>
+      <id>T1552.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="427560" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process reading sensitive files - EMail Client-based Credential Stores [E1105].</description>
+    <field name="rulename" type="osmatch">Process reading sensitive files - EMail Client-based Credential Stores [E1105]</field>
+    <mitre>
+      <id>T1555</id>
+      <id>T1552.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="427570" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process reading sensitive files - Remote Assistance Tool-based Credential Stores [E1106].</description>
+    <field name="rulename" type="osmatch">Process reading sensitive files - Remote Assistance Tool-based Credential Stores [E1106]</field>
+    <mitre>
+      <id>T1555</id>
+      <id>T1552.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="427580" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process reading sensitive files - Database-based Credential Stores [E1107].</description>
+    <field name="rulename" type="osmatch">Process reading sensitive files - Database-based Credential Stores [E1107]</field>
+    <mitre>
+      <id>T1555</id>
+      <id>T1552.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="427590" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Reading Sensitive Files - Browser-based Credential Stores [E1108].</description>
+    <field name="rulename" type="osmatch">Process Reading Sensitive Files - Browser-based Credential Stores [E1108]</field>
+    <mitre>
+      <id>T1555.003</id>
+      <id>T1552.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="427600" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process reading sensitive files - Development tool-based Credential Stores [E1109].</description>
+    <field name="rulename" type="osmatch">Process reading sensitive files - Development tool-based Credential Stores [E1109]</field>
+    <mitre>
+      <id>T1555</id>
+      <id>T1552.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="427610" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential FSUtil disk space recon performed [E1110].</description>
+    <field name="rulename" type="osmatch">Potential FSUtil disk space recon performed [E1110]</field>
+    <mitre>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="427620" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Peripheral Device Discovery - Devcon.exe discovery activity [E1117].</description>
+    <field name="rulename" type="osmatch">Potential Peripheral Device Discovery - Devcon.exe discovery activity [E1117]</field>
+    <mitre>
+      <id>T1120</id>
+    </mitre>
+  </rule>
+
+  <rule id="427630" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote host discovery via WMI (LDAP namespace) [E1118].</description>
+    <field name="rulename" type="osmatch">Remote host discovery via WMI (LDAP namespace) [E1118]</field>
+    <mitre>
+      <id>T1018</id>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="427640" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: AntiVirus Enumeration via WMI query [E1119].</description>
+    <field name="rulename" type="osmatch">AntiVirus Enumeration via WMI query [E1119]</field>
+    <mitre>
+      <id>T1047</id>
+      <id>T1518.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427650" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: AntiVirus Enumeration via WMIC [E1120].</description>
+    <field name="rulename" type="osmatch">AntiVirus Enumeration via WMIC [E1120]</field>
+    <mitre>
+      <id>T1047</id>
+      <id>T1518.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427660" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential User SPN enumeration via PowerShell ADSISearcher/.NET [E1121].</description>
+    <field name="rulename" type="osmatch">Potential User SPN enumeration via PowerShell ADSISearcher/.NET [E1121]</field>
+    <mitre>
+      <id>T1087.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="427670" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential AD Group enumeration via PowerShell ADSISearcher/.NET [E1122].</description>
+    <field name="rulename" type="osmatch">Potential AD Group enumeration via PowerShell ADSISearcher/.NET [E1122]</field>
+    <mitre>
+      <id>T1069.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="427680" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Remote Host enumeration via PowerShell ADSISearcher/.NET [E1123].</description>
+    <field name="rulename" type="osmatch">Potential Remote Host enumeration via PowerShell ADSISearcher/.NET [E1123]</field>
+    <mitre>
+      <id>T1018</id>
+    </mitre>
+  </rule>
+
+  <rule id="427690" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential User Account enumeration via PowerShell ADSISearcher/.NET [E1124].</description>
+    <field name="rulename" type="osmatch">Potential User Account enumeration via PowerShell ADSISearcher/.NET [E1124]</field>
+    <mitre>
+      <id>T1087.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="427700" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential security service discovery via PowerShell (cmdlet) [E1125].</description>
+    <field name="rulename" type="osmatch">Potential security service discovery via PowerShell (cmdlet) [E1125]</field>
+    <mitre>
+      <id>T1007</id>
+    </mitre>
+  </rule>
+
+  <rule id="427710" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential security service registry key discovery via PowerShell [E1126].</description>
+    <field name="rulename" type="osmatch">Potential security service registry key discovery via PowerShell [E1126]</field>
+    <mitre>
+      <id>T1007</id>
+    </mitre>
+  </rule>
+
+  <rule id="427720" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential User SPN Enumeration via LDAP Command Line Tool [E1127].</description>
+    <field name="rulename" type="osmatch">Potential User SPN Enumeration via LDAP Command Line Tool [E1127]</field>
+    <mitre>
+      <id>T1558.003</id>
+      <id>T1087</id>
+    </mitre>
+  </rule>
+
+  <rule id="427730" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential AD Group Enumeration via LDAP Command Line Tool [E1128].</description>
+    <field name="rulename" type="osmatch">Potential AD Group Enumeration via LDAP Command Line Tool [E1128]</field>
+    <mitre>
+      <id>T1069.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="427740" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Remote Host Enumeration via LDAP Command Line Tool [E1129].</description>
+    <field name="rulename" type="osmatch">Potential Remote Host Enumeration via LDAP Command Line Tool [E1129]</field>
+    <mitre>
+      <id>T1018</id>
+    </mitre>
+  </rule>
+
+  <rule id="427750" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential User Account Enumeration via LDAP Command Line Tool [E1130].</description>
+    <field name="rulename" type="osmatch">Potential User Account Enumeration via LDAP Command Line Tool [E1130]</field>
+    <mitre>
+      <id>T1087</id>
+    </mitre>
+  </rule>
+
+  <rule id="427760" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Defense Evasion - A service has been disabled via startup registry setting [E1201].</description>
+    <field name="rulename" type="osmatch">Potential Defense Evasion - A service has been disabled via startup registry setting [E1201]</field>
+    <mitre>
+      <id>T1112</id>
+      <id>T1489</id>
+    </mitre>
+  </rule>
+
+  <rule id="427770" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Local FW Modification: Netsh.exe rule to block outound UDP ports(53,137) [E1202].</description>
+    <field name="rulename" type="osmatch">Local FW Modification: Netsh.exe rule to block outound UDP ports(53,137) [E1202]</field>
+    <mitre>
+      <id>T1562.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="427780" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Defense Evasion - Security service disabled via registry setting [E1203].</description>
+    <field name="rulename" type="osmatch">Potential Defense Evasion - Security service disabled via registry setting [E1203]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1112</id>
+      <id>T1489</id>
+    </mitre>
+  </rule>
+
+  <rule id="427790" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Reg.exe command executed [E1204].</description>
+    <field name="rulename" type="osmatch">Remote Reg.exe command executed [E1204]</field>
+    <mitre>
+      <id>T1112</id>
+      <id>T1012</id>
+    </mitre>
+  </rule>
+
+  <rule id="427800" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Security Service Interaction via Reg.exe [E1205].</description>
+    <field name="rulename" type="osmatch">Remote Security Service Interaction via Reg.exe [E1205]</field>
+    <mitre>
+      <id>T1112</id>
+      <id>T1012</id>
+      <id>T1562.001</id>
+      <id>T1489</id>
+    </mitre>
+  </rule>
+
+  <rule id="427810" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: HTTP proxy related registry key removal [E1206].</description>
+    <field name="rulename" type="osmatch">HTTP proxy related registry key removal [E1206]</field>
+    <mitre>
+      <id>T1112</id>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427820" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Microsoft Defender Scan Exclusion Added Using PowerShell [E1207].</description>
+    <field name="rulename" type="osmatch">Microsoft Defender Scan Exclusion Added Using PowerShell [E1207]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427830" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Large Registry value set [F0102].</description>
+    <field name="rulename" type="osmatch">Large Registry value set [F0102]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="427840" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Very large Registry value set [F0103].</description>
+    <field name="rulename" type="osmatch">Very large Registry value set [F0103]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="427850" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Batch script started from Startup Folder [F0104].</description>
+    <field name="rulename" type="osmatch">Batch script started from Startup Folder [F0104]</field>
+    <mitre>
+      <id>T1547.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427860" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process started from Startup Folder [F0105].</description>
+    <field name="rulename" type="osmatch">Process started from Startup Folder [F0105]</field>
+    <mitre>
+      <id>T1547.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="427870" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User account was created [F0106].</description>
+    <field name="rulename" type="osmatch">User account was created [F0106]</field>
+    <mitre>
+      <id>T1136</id>
+    </mitre>
+  </rule>
+
+  <rule id="427880" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Scheduling suspicious task [F0107].</description>
+    <field name="rulename" type="osmatch">Scheduling suspicious task [F0107]</field>
+    <mitre>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="427890" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Script interpreter modified file in %startup% folder [F0108].</description>
+    <field name="rulename" type="osmatch">Script interpreter modified file in %startup% folder [F0108]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="427900" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Scheduling script task [F0109].</description>
+    <field name="rulename" type="osmatch">Scheduling script task [F0109]</field>
+    <mitre>
+      <id>T1053.005</id>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="427910" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Shortcut created in startup folder [F0111].</description>
+    <field name="rulename" type="osmatch">Shortcut created in startup folder [F0111]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1547.009</id>
+    </mitre>
+  </rule>
+
+  <rule id="427920" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious shortcut executed from Startup [F0112].</description>
+    <field name="rulename" type="osmatch">Suspicious shortcut executed from Startup [F0112]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1547.009</id>
+    </mitre>
+  </rule>
+
+  <rule id="427930" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Active Setup autostart registry modified by a compromised process [F0113].</description>
+    <field name="rulename" type="osmatch">Active Setup autostart registry modified by a compromised process [F0113]</field>
+    <mitre>
+      <id>T1547.014</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="427940" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Common AutoStart registry modified by compromised process [F0114].</description>
+    <field name="rulename" type="osmatch">Common AutoStart registry modified by compromised process [F0114]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="427950" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Session Manager AutoStart registry modified by compromised process [F0115].</description>
+    <field name="rulename" type="osmatch">Session Manager AutoStart registry modified by compromised process [F0115]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="427960" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Credential Providers registry modified by a compromised process [F0116].</description>
+    <field name="rulename" type="osmatch">Credential Providers registry modified by a compromised process [F0116]</field>
+    <mitre>
+      <id>T1547</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="427970" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Browser Helper Objects registry modified by a compromised process [F0117].</description>
+    <field name="rulename" type="osmatch">Browser Helper Objects registry modified by a compromised process [F0117]</field>
+    <mitre>
+      <id>T1176</id>
+      <id>T1185</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="427980" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows NT Drivers32 registry modified by compromised process [F0118].</description>
+    <field name="rulename" type="osmatch">Windows NT Drivers32 registry modified by compromised process [F0118]</field>
+    <mitre>
+      <id>T1574</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="427990" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Winlogon autostart registry was modified by compromised process [F0119].</description>
+    <field name="rulename" type="osmatch">Winlogon autostart registry was modified by compromised process [F0119]</field>
+    <mitre>
+      <id>T1547.004</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="428000" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: ShellIconOverlayIdentifiers registry modified by compromised process [F0120].</description>
+    <field name="rulename" type="osmatch">ShellIconOverlayIdentifiers registry modified by compromised process [F0120]</field>
+    <mitre>
+      <id>T1546.015</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="428010" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Subsystem for Linux enabled [F0200].</description>
+    <field name="rulename" type="osmatch">Windows Subsystem for Linux enabled [F0200]</field>
+    <mitre>
+      <id>T1202</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="428020" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Outlook security registry was modified [F0201].</description>
+    <field name="rulename" type="osmatch">Outlook security registry was modified [F0201]</field>
+    <mitre>
+      <id>T1562</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="428030" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Certificate added to CERT ROOT by compromised process [F0202].</description>
+    <field name="rulename" type="osmatch">Certificate added to CERT ROOT by compromised process [F0202]</field>
+    <mitre>
+      <id>T1553.004</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="428040" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Startup folder location registry modified by compromised process [F0205].</description>
+    <field name="rulename" type="osmatch">Startup folder location registry modified by compromised process [F0205]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1112</id>
+      <id>T1036</id>
+    </mitre>
+  </rule>
+
+  <rule id="428050" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PromptOnSecureDesktop modified by compromised process [F0206].</description>
+    <field name="rulename" type="osmatch">PromptOnSecureDesktop modified by compromised process [F0206]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="428060" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: LSA registry entry was modified by a compromised process [F0207].</description>
+    <field name="rulename" type="osmatch">LSA registry entry was modified by a compromised process [F0207]</field>
+    <mitre>
+      <id>T1547.008</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="428070" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: DisableRestrictedAdmin registry value was modified [F0208].</description>
+    <field name="rulename" type="osmatch">DisableRestrictedAdmin registry value was modified [F0208]</field>
+    <mitre>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="428080" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: CPL applet module drop [F0300].</description>
+    <field name="rulename" type="osmatch">CPL applet module drop [F0300]</field>
+    <mitre>
+      <id>T1218.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="428090" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Outlook macro file was dropped [F0301].</description>
+    <field name="rulename" type="osmatch">Outlook macro file was dropped [F0301]</field>
+    <mitre>
+      <id>T1137</id>
+    </mitre>
+  </rule>
+
+  <rule id="428100" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Software vendor Masquerading - creation [F0302].</description>
+    <field name="rulename" type="osmatch">Software vendor Masquerading - creation [F0302]</field>
+    <mitre>
+      <id>T1036</id>
+    </mitre>
+  </rule>
+
+  <rule id="428110" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Compromised process has written to the Recycle Bin folder [F0303].</description>
+    <field name="rulename" type="osmatch">Compromised process has written to the Recycle Bin folder [F0303]</field>
+    <mitre>
+      <id>T1564</id>
+      <id>T1074.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428120" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: ADS wrote by compromised process [F0304].</description>
+    <field name="rulename" type="osmatch">ADS wrote by compromised process [F0304]</field>
+    <mitre>
+      <id>T1564.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="428130" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Zone.Identifier deleted by compromised process [F0305].</description>
+    <field name="rulename" type="osmatch">Zone.Identifier deleted by compromised process [F0305]</field>
+    <mitre>
+      <id>T1564.004</id>
+      <id>T1070.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="428140" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious file dropped from email document [F0308].</description>
+    <field name="rulename" type="osmatch">Suspicious file dropped from email document [F0308]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+      <id>T1203</id>
+      <id>T1566.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428150" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Log Deletion [F0309].</description>
+    <field name="rulename" type="osmatch">Windows Log Deletion [F0309]</field>
+    <mitre>
+      <id>T1070.001</id>
+      <id>T1070.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="428160" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Perl backdoor activity - child process [F0400].</description>
+    <field name="rulename" type="osmatch">Perl backdoor activity - child process [F0400]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="428170" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Python backdoor activity - child process [F0401].</description>
+    <field name="rulename" type="osmatch">Python backdoor activity - child process [F0401]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="428180" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Generic Apache backdoor activity - child process [F0402].</description>
+    <field name="rulename" type="osmatch">Generic Apache backdoor activity - child process [F0402]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="428190" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Generic IIS backdoor activity - child process [F0403].</description>
+    <field name="rulename" type="osmatch">Generic IIS backdoor activity - child process [F0403]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="428200" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PHP backdoor activity - child process [F0404].</description>
+    <field name="rulename" type="osmatch">PHP backdoor activity - child process [F0404]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="428210" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Rundll32.exe executed javascript [F0405a].</description>
+    <field name="rulename" type="osmatch">Rundll32.exe executed javascript [F0405a]</field>
+    <mitre>
+      <id>T1218.011</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="428220" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Rundll32.exe executed javascript [F0405b].</description>
+    <field name="rulename" type="osmatch">Rundll32.exe executed javascript [F0405b]</field>
+    <mitre>
+      <id>T1218.011</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="428230" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Rundll32.exe process execution via DLL [F0406].</description>
+    <field name="rulename" type="osmatch">Rundll32.exe process execution via DLL [F0406]</field>
+    <mitre>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="428240" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: CPL applet execution [F0407].</description>
+    <field name="rulename" type="osmatch">CPL applet execution [F0407]</field>
+    <mitre>
+      <id>T1218.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="428250" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Rundll32 loaded DLL from suspicious location [F0410].</description>
+    <field name="rulename" type="osmatch">Rundll32 loaded DLL from suspicious location [F0410]</field>
+    <mitre>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="428260" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Unpopular process executed from a Scheduled Task [F0411].</description>
+    <field name="rulename" type="osmatch">Unpopular process executed from a Scheduled Task [F0411]</field>
+    <mitre>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="428270" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection into LSASS process - credential dumping [F0412].</description>
+    <field name="rulename" type="osmatch">Injection into LSASS process - credential dumping [F0412]</field>
+    <mitre>
+      <id>T1055</id>
+      <id>T1003.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428280" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection into system process [F0413a][C].</description>
+    <field name="rulename" type="osmatch">Injection into system process [F0413a][C]</field>
+    <mitre>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="428290" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection into system process [F0413b].</description>
+    <field name="rulename" type="osmatch">Injection into system process [F0413b]</field>
+    <mitre>
+      <id>T1055.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="428300" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection into system process [F0413c][C].</description>
+    <field name="rulename" type="osmatch">Injection into system process [F0413c][C]</field>
+    <mitre>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="428310" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection into trusted process [F0414a][C].</description>
+    <field name="rulename" type="osmatch">Injection into trusted process [F0414a][C]</field>
+    <mitre>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="428320" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection into trusted process [F0414b].</description>
+    <field name="rulename" type="osmatch">Injection into trusted process [F0414b]</field>
+    <mitre>
+      <id>T1055.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="428330" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection into trusted process [F0414c][C].</description>
+    <field name="rulename" type="osmatch">Injection into trusted process [F0414c][C]</field>
+    <mitre>
+      <id>T1055.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="428340" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection into trusted process [F0414d][C].</description>
+    <field name="rulename" type="osmatch">Injection into trusted process [F0414d][C]</field>
+    <mitre>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="428350" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection from an unpopular process [F0415].</description>
+    <field name="rulename" type="osmatch">Injection from an unpopular process [F0415]</field>
+    <mitre>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="428360" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection into browser process [F0416][C].</description>
+    <field name="rulename" type="osmatch">Injection into browser process [F0416][C]</field>
+    <mitre>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="428370" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection into email client process [F0417][C].</description>
+    <field name="rulename" type="osmatch">Injection into email client process [F0417][C]</field>
+    <mitre>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="428380" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection into file manager process [F0418][C].</description>
+    <field name="rulename" type="osmatch">Injection into file manager process [F0418][C]</field>
+    <mitre>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="428390" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Injection into IM process [F0419][C].</description>
+    <field name="rulename" type="osmatch">Injection into IM process [F0419][C]</field>
+    <mitre>
+      <id>T1055</id>
+    </mitre>
+  </rule>
+
+  <rule id="428400" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious script interpreter process tree - browsers [F0420a].</description>
+    <field name="rulename" type="osmatch">Suspicious script interpreter process tree - browsers [F0420a]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+      <id>T1203</id>
+    </mitre>
+  </rule>
+
+  <rule id="428410" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious script interpreter process tree - Microsoft Office [F0420b].</description>
+    <field name="rulename" type="osmatch">Suspicious script interpreter process tree - Microsoft Office [F0420b]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+      <id>T1203</id>
+    </mitre>
+  </rule>
+
+  <rule id="428420" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious script interpreter process tree - PDF readers [F0420c].</description>
+    <field name="rulename" type="osmatch">Suspicious script interpreter process tree - PDF readers [F0420c]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+      <id>T1203</id>
+    </mitre>
+  </rule>
+
+  <rule id="428430" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious script interpreter process tree - Microsoft Outlook [F0420d].</description>
+    <field name="rulename" type="osmatch">Suspicious script interpreter process tree - Microsoft Outlook [F0420d]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+      <id>T1203</id>
+      <id>T1566.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428440" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious rundll32 process [F0430].</description>
+    <field name="rulename" type="osmatch">Suspicious rundll32 process [F0430]</field>
+    <mitre>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="428450" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Kali started on WSL [F0433a].</description>
+    <field name="rulename" type="osmatch">Kali started on WSL [F0433a]</field>
+    <mitre>
+      <id>T1202</id>
+    </mitre>
+  </rule>
+
+  <rule id="428460" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Kali started on WSL [F0433b].</description>
+    <field name="rulename" type="osmatch">Kali started on WSL [F0433b]</field>
+    <mitre>
+      <id>T1202</id>
+    </mitre>
+  </rule>
+
+  <rule id="428470" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WSL2 file system process started [F0434].</description>
+    <field name="rulename" type="osmatch">WSL2 file system process started [F0434]</field>
+    <mitre>
+      <id>T1202</id>
+    </mitre>
+  </rule>
+
+  <rule id="428480" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Native process started from WSL [F0435].</description>
+    <field name="rulename" type="osmatch">Native process started from WSL [F0435]</field>
+    <mitre>
+      <id>T1202</id>
+    </mitre>
+  </rule>
+
+  <rule id="428490" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential credential dumping - Generic [F0436a].</description>
+    <field name="rulename" type="osmatch">Potential credential dumping - Generic [F0436a]</field>
+    <mitre>
+      <id>T1003.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428500" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential credential dumping - Generic [F0436b].</description>
+    <field name="rulename" type="osmatch">Potential credential dumping - Generic [F0436b]</field>
+    <mitre>
+      <id>T1003.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428510" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential credential dumping - Generic [F0436c].</description>
+    <field name="rulename" type="osmatch">Potential credential dumping - Generic [F0436c]</field>
+    <mitre>
+      <id>T1003.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428520" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential credential dumping - Mimikatz [F0437a][C].</description>
+    <field name="rulename" type="osmatch">Potential credential dumping - Mimikatz [F0437a][C]</field>
+    <mitre>
+      <id>T1003.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428530" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential credential dumping - Mimikatz [F0437b][C].</description>
+    <field name="rulename" type="osmatch">Potential credential dumping - Mimikatz [F0437b][C]</field>
+    <mitre>
+      <id>T1003.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428540" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential credential dumping - Mimikatz [F0437c].</description>
+    <field name="rulename" type="osmatch">Potential credential dumping - Mimikatz [F0437c]</field>
+    <mitre>
+      <id>T1003.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428550" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Outlook started with macro [F0438].</description>
+    <field name="rulename" type="osmatch">Outlook started with macro [F0438]</field>
+    <mitre>
+      <id>T1059.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="428560" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Mshta with inline script executed [F0439].</description>
+    <field name="rulename" type="osmatch">Mshta with inline script executed [F0439]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+      <id>T1218.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="428570" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: mshta.exe executed under a different name [F0440][C].</description>
+    <field name="rulename" type="osmatch">mshta.exe executed under a different name [F0440][C]</field>
+    <mitre>
+      <id>T1218.005</id>
+      <id>T1036.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="428580" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: wmic.exe executed under a different name [F0441][C].</description>
+    <field name="rulename" type="osmatch">wmic.exe executed under a different name [F0441][C]</field>
+    <mitre>
+      <id>T1036.003</id>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="428590" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Scheduled script task started [F0442].</description>
+    <field name="rulename" type="osmatch">Scheduled script task started [F0442]</field>
+    <mitre>
+      <id>T1053.005</id>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="428600" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Script started from %TEMP% [F0443a].</description>
+    <field name="rulename" type="osmatch">Script started from %TEMP% [F0443a]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="428610" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Script started from Outlook %TEMP% [F0443b].</description>
+    <field name="rulename" type="osmatch">Script started from Outlook %TEMP% [F0443b]</field>
+    <mitre>
+      <id>T1566.001</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="428620" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Delayed file deletion [F0444].</description>
+    <field name="rulename" type="osmatch">Delayed file deletion [F0444]</field>
+    <mitre>
+      <id>T1070.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="428630" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Indirect Command Execution [F0445].</description>
+    <field name="rulename" type="osmatch">Indirect Command Execution [F0445]</field>
+    <mitre>
+      <id>T1202</id>
+    </mitre>
+  </rule>
+
+  <rule id="428640" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Script with unusual extension was executed [F0446].</description>
+    <field name="rulename" type="osmatch">Script with unusual extension was executed [F0446]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="428650" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious script interpreter started - powershell [F0447a].</description>
+    <field name="rulename" type="osmatch">Suspicious script interpreter started - powershell [F0447a]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="428660" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious script interpreter started - cscript [F0447b].</description>
+    <field name="rulename" type="osmatch">Suspicious script interpreter started - cscript [F0447b]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="428670" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious script interpreter started - wscript [F0447c].</description>
+    <field name="rulename" type="osmatch">Suspicious script interpreter started - wscript [F0447c]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="428680" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious script interpreter started - cmd [F0447d].</description>
+    <field name="rulename" type="osmatch">Suspicious script interpreter started - cmd [F0447d]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="428690" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious script interpreter started - mshta [F0447e].</description>
+    <field name="rulename" type="osmatch">Suspicious script interpreter started - mshta [F0447e]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+      <id>T1218.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="428700" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User execution - suspicious cmd [F0448a].</description>
+    <field name="rulename" type="osmatch">User execution - suspicious cmd [F0448a]</field>
+    <mitre>
+      <id>T1204</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="428710" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User execution - suspicious powershell [F0448b].</description>
+    <field name="rulename" type="osmatch">User execution - suspicious powershell [F0448b]</field>
+    <mitre>
+      <id>T1204</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428720" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Minimized program started [F0449a].</description>
+    <field name="rulename" type="osmatch">Minimized program started [F0449a]</field>
+    <mitre>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="428730" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Minimized script interpreter started [F0449b].</description>
+    <field name="rulename" type="osmatch">Minimized script interpreter started [F0449b]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="428740" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential DLL search order hijacking - untrusted system libs [F0450a].</description>
+    <field name="rulename" type="osmatch">Potential DLL search order hijacking - untrusted system libs [F0450a]</field>
+    <mitre>
+      <id>T1574.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428750" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential DLL search order hijacking - untrusted system libs [F0450b].</description>
+    <field name="rulename" type="osmatch">Potential DLL search order hijacking - untrusted system libs [F0450b]</field>
+    <mitre>
+      <id>T1574.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428760" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential DLL search order hijacking - creation [F0450c].</description>
+    <field name="rulename" type="osmatch">Potential DLL search order hijacking - creation [F0450c]</field>
+    <mitre>
+      <id>T1574.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428770" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious DNS request via nslookup [F0451a].</description>
+    <field name="rulename" type="osmatch">Suspicious DNS request via nslookup [F0451a]</field>
+    <mitre>
+      <id>T1048.003</id>
+      <id>T1041</id>
+      <id>T1071.004</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="428780" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious DNS request via nslookup [F0451b].</description>
+    <field name="rulename" type="osmatch">Suspicious DNS request via nslookup [F0451b]</field>
+    <mitre>
+      <id>T1048.003</id>
+      <id>T1041</id>
+      <id>T1071.004</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="428790" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process started from DCOM Office app [F0452].</description>
+    <field name="rulename" type="osmatch">Process started from DCOM Office app [F0452]</field>
+    <mitre>
+      <id>T1021.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="428800" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Netsh firewall rules manipulation [F0453].</description>
+    <field name="rulename" type="osmatch">Netsh firewall rules manipulation [F0453]</field>
+    <mitre>
+      <id>T1562.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="428810" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Signed unpopular DLL loaded [F0455].</description>
+    <field name="rulename" type="osmatch">Signed unpopular DLL loaded [F0455]</field>
+    <mitre>
+      <id>T1553.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="428820" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Software vendor Masquerading [F0456].</description>
+    <field name="rulename" type="osmatch">Software vendor Masquerading [F0456]</field>
+    <mitre>
+      <id>T1036.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="428830" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Proxy execution - Regsvcs/Regasm [F0457].</description>
+    <field name="rulename" type="osmatch">Proxy execution - Regsvcs/Regasm [F0457]</field>
+    <mitre>
+      <id>T1218.009</id>
+    </mitre>
+  </rule>
+
+  <rule id="428840" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious shortcut executed [F0458a].</description>
+    <field name="rulename" type="osmatch">Suspicious shortcut executed [F0458a]</field>
+    <mitre>
+      <id>T1204</id>
+    </mitre>
+  </rule>
+
+  <rule id="428850" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious shortcut executed [F0458b].</description>
+    <field name="rulename" type="osmatch">Suspicious shortcut executed [F0458b]</field>
+    <mitre>
+      <id>T1204</id>
+    </mitre>
+  </rule>
+
+  <rule id="428860" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Command prompt with compromised parent process [F0459].</description>
+    <field name="rulename" type="osmatch">Command prompt with compromised parent process [F0459]</field>
+    <mitre>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="428870" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Rundll32 loaded DLL with unusual extension [F0461].</description>
+    <field name="rulename" type="osmatch">Rundll32 loaded DLL with unusual extension [F0461]</field>
+    <mitre>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="428880" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Computer was shut down [F0462a].</description>
+    <field name="rulename" type="osmatch">Computer was shut down [F0462a]</field>
+    <mitre>
+      <id>T1529</id>
+    </mitre>
+  </rule>
+
+  <rule id="428890" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Computer was restarted [F0462b].</description>
+    <field name="rulename" type="osmatch">Computer was restarted [F0462b]</field>
+    <mitre>
+      <id>T1529</id>
+    </mitre>
+  </rule>
+
+  <rule id="428900" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Scheduled shut down executed [F0462c].</description>
+    <field name="rulename" type="osmatch">Scheduled shut down executed [F0462c]</field>
+    <mitre>
+      <id>T1529</id>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="428910" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Scheduled restart executed [F0462d].</description>
+    <field name="rulename" type="osmatch">Scheduled restart executed [F0462d]</field>
+    <mitre>
+      <id>T1529</id>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="428920" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious shut down executed [F0462e].</description>
+    <field name="rulename" type="osmatch">Suspicious shut down executed [F0462e]</field>
+    <mitre>
+      <id>T1529</id>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="428930" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Scheduling shutdown task [F0463].</description>
+    <field name="rulename" type="osmatch">Scheduling shutdown task [F0463]</field>
+    <mitre>
+      <id>T1529</id>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="428940" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed PHP interpreter [F0464].</description>
+    <field name="rulename" type="osmatch">Renamed PHP interpreter [F0464]</field>
+    <mitre>
+      <id>T1036</id>
+      <id>T1059</id>
+    </mitre>
+  </rule>
+
+  <rule id="428950" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious OpenSSL execution [F0465].</description>
+    <field name="rulename" type="osmatch">Suspicious OpenSSL execution [F0465]</field>
+    <mitre>
+      <id>T1140</id>
+    </mitre>
+  </rule>
+
+  <rule id="428960" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious scheduled executable - OpenSSL, PHP [F0466].</description>
+    <field name="rulename" type="osmatch">Suspicious scheduled executable - OpenSSL, PHP [F0466]</field>
+    <mitre>
+      <id>T1053</id>
+    </mitre>
+  </rule>
+
+  <rule id="428970" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious encoded localhost IP [F0467].</description>
+    <field name="rulename" type="osmatch">Suspicious encoded localhost IP [F0467]</field>
+    <mitre>
+      <id>T1027</id>
+    </mitre>
+  </rule>
+
+  <rule id="428980" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Admin share mapping [F0468].</description>
+    <field name="rulename" type="osmatch">Admin share mapping [F0468]</field>
+    <mitre>
+      <id>T1021.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="428990" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WmiPrvSE started script interpreter [F0469].</description>
+    <field name="rulename" type="osmatch">WmiPrvSE started script interpreter [F0469]</field>
+    <mitre>
+      <id>T1047</id>
+      <id>T1059</id>
+    </mitre>
+  </rule>
+
+  <rule id="429000" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed cloudflared - Network [F0470a].</description>
+    <field name="rulename" type="osmatch">Renamed cloudflared - Network [F0470a]</field>
+    <mitre>
+      <id>T1036</id>
+      <id>T1572</id>
+    </mitre>
+  </rule>
+
+  <rule id="429010" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed cloudflared - Command Line [F0470b].</description>
+    <field name="rulename" type="osmatch">Renamed cloudflared - Command Line [F0470b]</field>
+    <mitre>
+      <id>T1036</id>
+      <id>T1572</id>
+    </mitre>
+  </rule>
+
+  <rule id="429020" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed cloudflared - Service [F0470c].</description>
+    <field name="rulename" type="osmatch">Renamed cloudflared - Service [F0470c]</field>
+    <mitre>
+      <id>T1036</id>
+      <id>T1572</id>
+      <id>T1543.003</id>
+      <id>T1569.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="429030" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Proxy DLL Execution - msiexec [F0473].</description>
+    <field name="rulename" type="osmatch">Proxy DLL Execution - msiexec [F0473]</field>
+    <mitre>
+      <id>T1218.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="429040" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Nslookup wrote a file [F0500].</description>
+    <field name="rulename" type="osmatch">Nslookup wrote a file [F0500]</field>
+    <mitre>
+      <id>T1048.003</id>
+      <id>T1041</id>
+      <id>T1071.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="429050" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Cobalt Strike DNS request [F0501].</description>
+    <field name="rulename" type="osmatch">Potential Cobalt Strike DNS request [F0501]</field>
+    <mitre>
+      <id>T1048.003</id>
+      <id>T1041</id>
+      <id>T1071.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="429060" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Connection to DCOM Office app [F0502].</description>
+    <field name="rulename" type="osmatch">Connection to DCOM Office app [F0502]</field>
+    <mitre>
+      <id>T1021.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="429070" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Compromised process communicating over Suspicious Email Protocol [F0503].</description>
+    <field name="rulename" type="osmatch">Compromised process communicating over Suspicious Email Protocol [F0503]</field>
+    <mitre>
+      <id>T1071.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="429080" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Compromised process makes HTTP request to a PasteBin-like site [F0504].</description>
+    <field name="rulename" type="osmatch">Compromised process makes HTTP request to a PasteBin-like site [F0504]</field>
+    <mitre>
+      <id>T1102</id>
+    </mitre>
+  </rule>
+
+  <rule id="429090" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Compromised process made HTTP request to a popular Web Service [F0505].</description>
+    <field name="rulename" type="osmatch">Compromised process made HTTP request to a popular Web Service [F0505]</field>
+    <mitre>
+      <id>T1102</id>
+    </mitre>
+  </rule>
+
+  <rule id="429100" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Compromised process made suspicious http query [F0507].</description>
+    <field name="rulename" type="osmatch">Compromised process made suspicious http query [F0507]</field>
+    <mitre>
+      <id>T1071.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429110" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network connection accepted by compromised process [F0508].</description>
+    <field name="rulename" type="osmatch">Network connection accepted by compromised process [F0508]</field>
+    <mitre>
+      <id>T1090</id>
+      <id>T1205</id>
+    </mitre>
+  </rule>
+
+  <rule id="429120" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network connection from wscript.exe started from a compromised process [F0509a].</description>
+    <field name="rulename" type="osmatch">Network connection from wscript.exe started from a compromised process [F0509a]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="429130" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network connection from wscript.exe started from a compromised process [F0509b].</description>
+    <field name="rulename" type="osmatch">Network connection from wscript.exe started from a compromised process [F0509b]</field>
+    <mitre>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="429140" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Internal network connection from rundll32.exe started from a compromised process [F0510a].</description>
+    <field name="rulename" type="osmatch">Internal network connection from rundll32.exe started from a compromised process [F0510a]</field>
+    <mitre>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="429150" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: External network connection from rundll32.exe started from a compromised process [F0510b].</description>
+    <field name="rulename" type="osmatch">External network connection from rundll32.exe started from a compromised process [F0510b]</field>
+    <mitre>
+      <id>T1218.011</id>
+    </mitre>
+  </rule>
+
+  <rule id="429160" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious 3rd-party web service communication [F0511].</description>
+    <field name="rulename" type="osmatch">Suspicious 3rd-party web service communication [F0511]</field>
+    <mitre>
+      <id>T1071.001</id>
+      <id>T1102.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429170" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Excel Add-in registry modified [F0800].</description>
+    <field name="rulename" type="osmatch">Excel Add-in registry modified [F0800]</field>
+    <mitre>
+      <id>T1137.006</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="429180" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Excel Add-In created [F0801].</description>
+    <field name="rulename" type="osmatch">Suspicious Excel Add-In created [F0801]</field>
+    <mitre>
+      <id>T1137.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="429190" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Word Add-In created [F0802].</description>
+    <field name="rulename" type="osmatch">Suspicious Word Add-In created [F0802]</field>
+    <mitre>
+      <id>T1137.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="429200" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: VBA Excel Add-In created [F0803].</description>
+    <field name="rulename" type="osmatch">VBA Excel Add-In created [F0803]</field>
+    <mitre>
+      <id>T1137.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="429210" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: VBA PowerPoint Add-In created [F0804].</description>
+    <field name="rulename" type="osmatch">VBA PowerPoint Add-In created [F0804]</field>
+    <mitre>
+      <id>T1137.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="429220" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote user login [F0900].</description>
+    <field name="rulename" type="osmatch">Remote user login [F0900]</field>
+    <mitre>
+      <id>T1021.001</id>
+      <id>T1078</id>
+    </mitre>
+  </rule>
+
+  <rule id="429230" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote execution using PAExec [F0901].</description>
+    <field name="rulename" type="osmatch">Remote execution using PAExec [F0901]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429240" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote execution using wmiexec [F0902].</description>
+    <field name="rulename" type="osmatch">Remote execution using wmiexec [F0902]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="429250" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote execution using smbexec [F0903a].</description>
+    <field name="rulename" type="osmatch">Remote execution using smbexec [F0903a]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429260" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote execution using smbexec [F0903b].</description>
+    <field name="rulename" type="osmatch">Remote execution using smbexec [F0903b]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1569.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="429270" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote execution using atexec [F0904].</description>
+    <field name="rulename" type="osmatch">Remote execution using atexec [F0904]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="429280" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote execution using dcomexec [F0905].</description>
+    <field name="rulename" type="osmatch">Remote execution using dcomexec [F0905]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1021.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="429290" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User was added to administrator group [F1000].</description>
+    <field name="rulename" type="osmatch">User was added to administrator group [F1000]</field>
+    <mitre>
+      <id>T1098</id>
+    </mitre>
+  </rule>
+
+  <rule id="429300" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User was removed from administrator group [F1001].</description>
+    <field name="rulename" type="osmatch">User was removed from administrator group [F1001]</field>
+    <mitre>
+      <id>T1098</id>
+      <id>T1531</id>
+    </mitre>
+  </rule>
+
+  <rule id="429310" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Pass-the-Hash user login [F1002].</description>
+    <field name="rulename" type="osmatch">Potential Pass-the-Hash user login [F1002]</field>
+    <mitre>
+      <id>T1550.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429320" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Volume USN journal was deleted [F1003].</description>
+    <field name="rulename" type="osmatch">Volume USN journal was deleted [F1003]</field>
+    <mitre>
+      <id>T1070</id>
+    </mitre>
+  </rule>
+
+  <rule id="429330" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Event Logging Service Stopped [F1009].</description>
+    <field name="rulename" type="osmatch">Windows Event Logging Service Stopped [F1009]</field>
+    <mitre>
+      <id>T1562.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429340" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Account Discovery - Local [F1100a].</description>
+    <field name="rulename" type="osmatch">Account Discovery - Local [F1100a]</field>
+    <mitre>
+      <id>T1087.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429350" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Account Discovery - Domain [F1100b].</description>
+    <field name="rulename" type="osmatch">Account Discovery - Domain [F1100b]</field>
+    <mitre>
+      <id>T1087.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429360" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Permission Groups Discovery - Local [F1102a].</description>
+    <field name="rulename" type="osmatch">Permission Groups Discovery - Local [F1102a]</field>
+    <mitre>
+      <id>T1069.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429370" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Permission Groups Discovery - Domain [F1102b].</description>
+    <field name="rulename" type="osmatch">Permission Groups Discovery - Domain [F1102b]</field>
+    <mitre>
+      <id>T1069.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429380" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Query Registry - remote [F1105].</description>
+    <field name="rulename" type="osmatch">Query Registry - remote [F1105]</field>
+    <mitre>
+      <id>T1012</id>
+    </mitre>
+  </rule>
+
+  <rule id="429390" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote System Discovery [F1106].</description>
+    <field name="rulename" type="osmatch">Remote System Discovery [F1106]</field>
+    <mitre>
+      <id>T1018</id>
+    </mitre>
+  </rule>
+
+  <rule id="429400" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Information Discovery [F1107].</description>
+    <field name="rulename" type="osmatch">System Information Discovery [F1107]</field>
+    <mitre>
+      <id>T1082</id>
+    </mitre>
+  </rule>
+
+  <rule id="429410" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Network Configuration Discovery [F1108a].</description>
+    <field name="rulename" type="osmatch">System Network Configuration Discovery [F1108a]</field>
+    <mitre>
+      <id>T1016</id>
+      <id>T1018</id>
+      <id>T1518.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429420" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Owner / User Discovery [F1109].</description>
+    <field name="rulename" type="osmatch">System Owner / User Discovery [F1109]</field>
+    <mitre>
+      <id>T1033</id>
+    </mitre>
+  </rule>
+
+  <rule id="429430" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Network Connections Discovery [F1111].</description>
+    <field name="rulename" type="osmatch">System Network Connections Discovery [F1111]</field>
+    <mitre>
+      <id>T1049</id>
+    </mitre>
+  </rule>
+
+  <rule id="429440" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network Share Discovery [F1113].</description>
+    <field name="rulename" type="osmatch">Network Share Discovery [F1113]</field>
+    <mitre>
+      <id>T1135</id>
+    </mitre>
+  </rule>
+
+  <rule id="429450" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Inbound Firewall Rule Added via PowerShell [F1200a].</description>
+    <field name="rulename" type="osmatch">Inbound Firewall Rule Added via PowerShell [F1200a]</field>
+    <mitre>
+      <id>T1562.004</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429460" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Outbound Firewall Rule Added via PowerShell [F1200c].</description>
+    <field name="rulename" type="osmatch">Outbound Firewall Rule Added via PowerShell [F1200c]</field>
+    <mitre>
+      <id>T1562.004</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429470" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Outbound Firewall Rule Added via PowerShell [F1200d].</description>
+    <field name="rulename" type="osmatch">Outbound Firewall Rule Added via PowerShell [F1200d]</field>
+    <mitre>
+      <id>T1562.004</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429480" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Firewall Profile Disabled via PowerShell [F1201a].</description>
+    <field name="rulename" type="osmatch">Firewall Profile Disabled via PowerShell [F1201a]</field>
+    <mitre>
+      <id>T1562.004</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429490" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Set to Executable - Hidden Folder / File [G0301B].</description>
+    <field name="rulename" type="osmatch">File Set to Executable - Hidden Folder / File [G0301B]</field>
+    <mitre>
+      <id>T1222.002</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429500" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Set to Executable - Suspicious Directory [G0301C].</description>
+    <field name="rulename" type="osmatch">File Set to Executable - Suspicious Directory [G0301C]</field>
+    <mitre>
+      <id>T1059.004</id>
+      <id>T1222.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429510" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Hidden File Dropped by Network Utility [G0302].</description>
+    <field name="rulename" type="osmatch">Hidden File Dropped by Network Utility [G0302]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1564.001</id>
+      <id>T1071.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429520" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Dropped by Network Utility into Suspicious Location [G0303].</description>
+    <field name="rulename" type="osmatch">File Dropped by Network Utility into Suspicious Location [G0303]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1071.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429530" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious File Dropped by Network Utility [G0305].</description>
+    <field name="rulename" type="osmatch">Suspicious File Dropped by Network Utility [G0305]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1071.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429540" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Dropped by Network Utility into Suspicious Location [G0306].</description>
+    <field name="rulename" type="osmatch">Archive Dropped by Network Utility into Suspicious Location [G0306]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="429550" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible Data Exfiltration via curl [G0501].</description>
+    <field name="rulename" type="osmatch">Possible Data Exfiltration via curl [G0501]</field>
+    <mitre>
+      <id>T1048.003</id>
+      <id>T1071.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429560" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Timestomp Attempt [G1001].</description>
+    <field name="rulename" type="osmatch">Potential Timestomp Attempt [G1001]</field>
+    <mitre>
+      <id>T1070.006</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="429570" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Reading User Shell History [G1101A].</description>
+    <field name="rulename" type="osmatch">Reading User Shell History [G1101A]</field>
+    <mitre>
+      <id>T1552.001</id>
+      <id>T1552.003</id>
+      <id>T1005</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="429580" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Reading Root Shell History [G1101B].</description>
+    <field name="rulename" type="osmatch">Reading Root Shell History [G1101B]</field>
+    <mitre>
+      <id>T1552.001</id>
+      <id>T1552.003</id>
+      <id>T1005</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="429590" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: MOTD File Added/Modified [H0100].</description>
+    <field name="rulename" type="osmatch">MOTD File Added/Modified [H0100]</field>
+    <mitre>
+      <id>T1059.004</id>
+      <id>T1037</id>
+    </mitre>
+  </rule>
+
+  <rule id="429600" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Use of usermod Utility Assigning Root UID [H0101].</description>
+    <field name="rulename" type="osmatch">Suspicious Use of usermod Utility Assigning Root UID [H0101]</field>
+    <mitre>
+      <id>T1078.003</id>
+      <id>T1548.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429610" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Systemd Generator Added/Modified [H0102].</description>
+    <field name="rulename" type="osmatch">Systemd Generator Added/Modified [H0102]</field>
+    <mitre>
+      <id>T1543.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429620" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Udev Rule Added/Modified [H0103].</description>
+    <field name="rulename" type="osmatch">Udev Rule Added/Modified [H0103]</field>
+    <mitre>
+      <id>T1546.017</id>
+    </mitre>
+  </rule>
+
+  <rule id="429630" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: UID/GID Capabilities Modified via setcap Utility [H0104].</description>
+    <field name="rulename" type="osmatch">UID/GID Capabilities Modified via setcap Utility [H0104]</field>
+    <mitre>
+      <id>T1548.001</id>
+      <id>T1222.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429640" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: base64 Utility Decoded Data into Executable [H0300].</description>
+    <field name="rulename" type="osmatch">base64 Utility Decoded Data into Executable [H0300]</field>
+    <mitre>
+      <id>T1140</id>
+      <id>T1105</id>
+      <id>T1027</id>
+    </mitre>
+  </rule>
+
+  <rule id="429650" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Interactive Shell Spawned from MOTD [H0400].</description>
+    <field name="rulename" type="osmatch">Interactive Shell Spawned from MOTD [H0400]</field>
+    <mitre>
+      <id>T1059.004</id>
+      <id>T1037</id>
+    </mitre>
+  </rule>
+
+  <rule id="429660" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Interactive Shell Spawned from Systemd Generator [H0401].</description>
+    <field name="rulename" type="osmatch">Interactive Shell Spawned from Systemd Generator [H0401]</field>
+    <mitre>
+      <id>T1059.004</id>
+      <id>T1543.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429670" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wiper AV Detection [I0101].</description>
+    <field name="rulename" type="osmatch">Wiper AV Detection [I0101]</field>
+    <mitre>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="429680" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Webshell AV Detection [I0102].</description>
+    <field name="rulename" type="osmatch">Webshell AV Detection [I0102]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="429690" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: LNK Malware Detected [I0104].</description>
+    <field name="rulename" type="osmatch">LNK Malware Detected [I0104]</field>
+    <mitre>
+      <id>T1204.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429700" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Filecoder Detected [I0108].</description>
+    <field name="rulename" type="osmatch">Filecoder Detected [I0108]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="429710" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: AV/EDR Disabler Detected [I0116].</description>
+    <field name="rulename" type="osmatch">AV/EDR Disabler Detected [I0116]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="429720" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Brute Force Attempt Detected [I0300].</description>
+    <field name="rulename" type="osmatch">Brute Force Attempt Detected [I0300]</field>
+    <mitre>
+      <id>T1110</id>
+    </mitre>
+  </rule>
+
+  <rule id="429730" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: AdFind Active Directory Enumeration [I0401].</description>
+    <field name="rulename" type="osmatch">AdFind Active Directory Enumeration [I0401]</field>
+    <mitre>
+      <id>T1087.002</id>
+      <id>T1482</id>
+      <id>T1069.002</id>
+      <id>T1018</id>
+      <id>T1016</id>
+    </mitre>
+  </rule>
+
+  <rule id="429740" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: UAC Bypass - fodhelper.exe [I0402].</description>
+    <field name="rulename" type="osmatch">UAC Bypass - fodhelper.exe [I0402]</field>
+    <mitre>
+      <id>T1548.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429750" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Scheduling with AT command [K0101].</description>
+    <field name="rulename" type="osmatch">Scheduling with AT command [K0101]</field>
+    <mitre>
+      <id>T1053.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429760" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: VSCode Remote Tunnel Usage [K0501].</description>
+    <field name="rulename" type="osmatch">VSCode Remote Tunnel Usage [K0501]</field>
+    <mitre>
+      <id>T1071.001</id>
+      <id>T1133</id>
+    </mitre>
+  </rule>
+
+  <rule id="429770" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User cron job added/modified [L0101A].</description>
+    <field name="rulename" type="osmatch">User cron job added/modified [L0101A]</field>
+    <mitre>
+      <id>T1053.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="429780" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System-wide cron job added/modified - specific interval [L0101B].</description>
+    <field name="rulename" type="osmatch">System-wide cron job added/modified - specific interval [L0101B]</field>
+    <mitre>
+      <id>T1053.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="429790" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System-wide cron job added/modified - variable interval [L0101C].</description>
+    <field name="rulename" type="osmatch">System-wide cron job added/modified - variable interval [L0101C]</field>
+    <mitre>
+      <id>T1053.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="429800" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User cron job added/modified - not via crontab [L0101D].</description>
+    <field name="rulename" type="osmatch">User cron job added/modified - not via crontab [L0101D]</field>
+    <mitre>
+      <id>T1053.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="429810" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Systemd Service Added - Runtime, Unusual Process [L0102A].</description>
+    <field name="rulename" type="osmatch">Systemd Service Added - Runtime, Unusual Process [L0102A]</field>
+    <mitre>
+      <id>T1543.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429820" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Systemd Service Added - Package Manager, Unusual Process [L0102B].</description>
+    <field name="rulename" type="osmatch">Systemd Service Added - Package Manager, Unusual Process [L0102B]</field>
+    <mitre>
+      <id>T1543.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429830" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Systemd Service Added - User / System [L0102C].</description>
+    <field name="rulename" type="osmatch">Systemd Service Added - User / System [L0102C]</field>
+    <mitre>
+      <id>T1543.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429840" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: XDG autostart entry added/modified [L0103].</description>
+    <field name="rulename" type="osmatch">XDG autostart entry added/modified [L0103]</field>
+    <mitre>
+      <id>T1547.013</id>
+    </mitre>
+  </rule>
+
+  <rule id="429850" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User shell configuration added/modified [L0104A].</description>
+    <field name="rulename" type="osmatch">User shell configuration added/modified [L0104A]</field>
+    <mitre>
+      <id>T1546.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="429860" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System-wide shell configuration added/modified [L0104B].</description>
+    <field name="rulename" type="osmatch">System-wide shell configuration added/modified [L0104B]</field>
+    <mitre>
+      <id>T1546.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="429870" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: RC script added/modified [L0105].</description>
+    <field name="rulename" type="osmatch">RC script added/modified [L0105]</field>
+    <mitre>
+      <id>T1037.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="429880" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible attempt at hijacking execution flow [L0106].</description>
+    <field name="rulename" type="osmatch">Possible attempt at hijacking execution flow [L0106]</field>
+    <mitre>
+      <id>T1574.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="429890" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Kernel module loaded/unloaded via insmod/rmmod [L0107].</description>
+    <field name="rulename" type="osmatch">Kernel module loaded/unloaded via insmod/rmmod [L0107]</field>
+    <mitre>
+      <id>T1547.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="429900" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Scheduled job (at) added/modified [L0108].</description>
+    <field name="rulename" type="osmatch">Scheduled job (at) added/modified [L0108]</field>
+    <mitre>
+      <id>T1053.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="429910" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Sysvinit/Upstart daemon added/modified [L0109].</description>
+    <field name="rulename" type="osmatch">Sysvinit/Upstart daemon added/modified [L0109]</field>
+    <mitre>
+      <id>T1037</id>
+    </mitre>
+  </rule>
+
+  <rule id="429920" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Systemd timer added/modified [L0110].</description>
+    <field name="rulename" type="osmatch">Systemd timer added/modified [L0110]</field>
+    <mitre>
+      <id>T1053.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="429930" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Boot kernel modules added/modified [L0111].</description>
+    <field name="rulename" type="osmatch">Boot kernel modules added/modified [L0111]</field>
+    <mitre>
+      <id>T1547.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="429940" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Dropped to a Suspicious Location [L0301].</description>
+    <field name="rulename" type="osmatch">File Dropped to a Suspicious Location [L0301]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1564.001</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="429950" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Tampering with Standard Utilities / Services [L0302].</description>
+    <field name="rulename" type="osmatch">Potential Tampering with Standard Utilities / Services [L0302]</field>
+    <mitre>
+      <id>T1036.003</id>
+      <id>T1036.005</id>
+      <id>T1554</id>
+    </mitre>
+  </rule>
+
+  <rule id="429960" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User Cron Job Deleted - not via crontab [L0303].</description>
+    <field name="rulename" type="osmatch">User Cron Job Deleted - not via crontab [L0303]</field>
+    <mitre>
+      <id>T1053.003</id>
+      <id>T1070.004</id>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="429970" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System-Wide Cron Job Deleted [L0304].</description>
+    <field name="rulename" type="osmatch">System-Wide Cron Job Deleted [L0304]</field>
+    <mitre>
+      <id>T1053.003</id>
+      <id>T1070.004</id>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="429980" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with a Standard Kernel Process Name Dropped [L0305].</description>
+    <field name="rulename" type="osmatch">File with a Standard Kernel Process Name Dropped [L0305]</field>
+    <mitre>
+      <id>T1036.004</id>
+      <id>T1036.005</id>
+      <id>T1105</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="429990" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with a Suspicious Extension Dropped [L0306].</description>
+    <field name="rulename" type="osmatch">File with a Suspicious Extension Dropped [L0306]</field>
+    <mitre>
+      <id>T1036</id>
+      <id>T1105</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="430000" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Tampered with standard Unix authentication module (PAM) [L0307].</description>
+    <field name="rulename" type="osmatch">Tampered with standard Unix authentication module (PAM) [L0307]</field>
+    <mitre>
+      <id>T1556.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="430010" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Set/unset file immutability via chattr [L0308].</description>
+    <field name="rulename" type="osmatch">Set/unset file immutability via chattr [L0308]</field>
+    <mitre>
+      <id>T1222.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="430020" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential coinminer-related behaviour - config.json in suspicious location [L0309].</description>
+    <field name="rulename" type="osmatch">Potential coinminer-related behaviour - config.json in suspicious location [L0309]</field>
+    <mitre>
+      <id>T1496</id>
+    </mitre>
+  </rule>
+
+  <rule id="430030" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible CVE-2021-4034 exploitation attempt - GCONV_PATH [L0310].</description>
+    <field name="rulename" type="osmatch">Possible CVE-2021-4034 exploitation attempt - GCONV_PATH [L0310]</field>
+    <mitre>
+      <id>T1068</id>
+      <id>T1574.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="430040" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File set to immutable [L0311A].</description>
+    <field name="rulename" type="osmatch">File set to immutable [L0311A]</field>
+    <mitre>
+      <id>T1222.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="430050" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File set to immutable - specific [L0311B].</description>
+    <field name="rulename" type="osmatch">File set to immutable - specific [L0311B]</field>
+    <mitre>
+      <id>T1222.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="430060" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File set to undeletable [L0312].</description>
+    <field name="rulename" type="osmatch">File set to undeletable [L0312]</field>
+    <mitre>
+      <id>T1222.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="430070" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process deleted its file [L0313].</description>
+    <field name="rulename" type="osmatch">Process deleted its file [L0313]</field>
+    <mitre>
+      <id>T1070.004</id>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="430080" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File SUID/SGID flag set [L0314].</description>
+    <field name="rulename" type="osmatch">File SUID/SGID flag set [L0314]</field>
+    <mitre>
+      <id>T1548.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430090" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Utility / Service Executed from a Non-Standard Location [L0315].</description>
+    <field name="rulename" type="osmatch">Utility / Service Executed from a Non-Standard Location [L0315]</field>
+    <mitre>
+      <id>T1554</id>
+      <id>T1036.004</id>
+      <id>T1036.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="430100" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Dropped by Network Transfer Utility / Service [L0316].</description>
+    <field name="rulename" type="osmatch">File Dropped by Network Transfer Utility / Service [L0316]</field>
+    <mitre>
+      <id>T1021.004</id>
+      <id>T1105</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="430110" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious File Dropped - Hidden [L0318A].</description>
+    <field name="rulename" type="osmatch">Suspicious File Dropped - Hidden [L0318A]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1564.001</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="430120" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious File Dropped - Hidden Directory [L0318B].</description>
+    <field name="rulename" type="osmatch">Suspicious File Dropped - Hidden Directory [L0318B]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1564.001</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="430130" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Set to Executable - Hidden [L0319A].</description>
+    <field name="rulename" type="osmatch">File Set to Executable - Hidden [L0319A]</field>
+    <mitre>
+      <id>T1222.002</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430140" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Set to Executable - Hidden Directory [L0319B].</description>
+    <field name="rulename" type="osmatch">File Set to Executable - Hidden Directory [L0319B]</field>
+    <mitre>
+      <id>T1222.002</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430150" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Deleted via shred [L0322C].</description>
+    <field name="rulename" type="osmatch">File Deleted via shred [L0322C]</field>
+    <mitre>
+      <id>T1070.004</id>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="430160" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Masquerading as Kernel Process [L0401].</description>
+    <field name="rulename" type="osmatch">Process Masquerading as Kernel Process [L0401]</field>
+    <mitre>
+      <id>T1036.004</id>
+      <id>T1036.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="430170" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious curl / wget Usage [L0402A].</description>
+    <field name="rulename" type="osmatch">Suspicious curl / wget Usage [L0402A]</field>
+    <mitre>
+      <id>T1020</id>
+      <id>T1041</id>
+      <id>T1105</id>
+      <id>T1567</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="430180" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious curl / wget Usage - Specific [L0402B].</description>
+    <field name="rulename" type="osmatch">Suspicious curl / wget Usage - Specific [L0402B]</field>
+    <mitre>
+      <id>T1020</id>
+      <id>T1041</id>
+      <id>T1105</id>
+      <id>T1567</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="430190" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible CVE-2021-4034 exploitation attempt - root shell spawned from pkexec [L0404].</description>
+    <field name="rulename" type="osmatch">Possible CVE-2021-4034 exploitation attempt - root shell spawned from pkexec [L0404]</field>
+    <mitre>
+      <id>T1059.004</id>
+      <id>T1068</id>
+    </mitre>
+  </rule>
+
+  <rule id="430200" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Coinminer Behavior - Suspicious Process [L0405].</description>
+    <field name="rulename" type="osmatch">Potential Coinminer Behavior - Suspicious Process [L0405]</field>
+    <mitre>
+      <id>T1496</id>
+    </mitre>
+  </rule>
+
+  <rule id="430210" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Base64 Data decoded via base64 Utility [L0406A].</description>
+    <field name="rulename" type="osmatch">Base64 Data decoded via base64 Utility [L0406A]</field>
+    <mitre>
+      <id>T1059.004</id>
+      <id>T1140</id>
+      <id>T1132</id>
+    </mitre>
+  </rule>
+
+  <rule id="430220" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Base64 Data Decoded via openssl Utility [L0406B].</description>
+    <field name="rulename" type="osmatch">Base64 Data Decoded via openssl Utility [L0406B]</field>
+    <mitre>
+      <id>T1059.004</id>
+      <id>T1140</id>
+      <id>T1132</id>
+    </mitre>
+  </rule>
+
+  <rule id="430230" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Base64 Data Decoded via Python [L0406C].</description>
+    <field name="rulename" type="osmatch">Base64 Data Decoded via Python [L0406C]</field>
+    <mitre>
+      <id>T1140</id>
+      <id>T1132</id>
+      <id>T1059.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="430240" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Base64 Data Decoded via Perl [L0406D].</description>
+    <field name="rulename" type="osmatch">Base64 Data Decoded via Perl [L0406D]</field>
+    <mitre>
+      <id>T1140</id>
+      <id>T1132</id>
+      <id>T1059</id>
+    </mitre>
+  </rule>
+
+  <rule id="430250" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Openssl decrypting data [L0407].</description>
+    <field name="rulename" type="osmatch">Openssl decrypting data [L0407]</field>
+    <mitre>
+      <id>T1140</id>
+      <id>T1132</id>
+    </mitre>
+  </rule>
+
+  <rule id="430260" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Executed File from Memory [L0408].</description>
+    <field name="rulename" type="osmatch">Executed File from Memory [L0408]</field>
+    <mitre>
+      <id>T1620</id>
+    </mitre>
+  </rule>
+
+  <rule id="430270" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Shell Spawned by a Web Server Process [L0409].</description>
+    <field name="rulename" type="osmatch">Shell Spawned by a Web Server Process [L0409]</field>
+    <mitre>
+      <id>T1505.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="430280" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Hidden File Executed from a Standard Location [L0410].</description>
+    <field name="rulename" type="osmatch">Hidden File Executed from a Standard Location [L0410]</field>
+    <mitre>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430290" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with a suspicious extension executed [L0411].</description>
+    <field name="rulename" type="osmatch">File with a suspicious extension executed [L0411]</field>
+    <mitre>
+      <id>T1036.008</id>
+    </mitre>
+  </rule>
+
+  <rule id="430300" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Executed from a Suspicious Location [L0412].</description>
+    <field name="rulename" type="osmatch">File Executed from a Suspicious Location [L0412]</field>
+    <mitre>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430310" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Usage of Script Interpreters - Python [L0413].</description>
+    <field name="rulename" type="osmatch">Suspicious Usage of Script Interpreters - Python [L0413]</field>
+    <mitre>
+      <id>T1059.004</id>
+      <id>T1059.006</id>
+      <id>T1105</id>
+      <id>T1140</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="430320" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process file content read by an unusual process [L0414].</description>
+    <field name="rulename" type="osmatch">Process file content read by an unusual process [L0414]</field>
+    <mitre>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="430330" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Interactive Shell Spawned from a Scheduled Job [L0415A].</description>
+    <field name="rulename" type="osmatch">Interactive Shell Spawned from a Scheduled Job [L0415A]</field>
+    <mitre>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="430340" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Interactive Shell Spawned from a Systemd Service [L0415B].</description>
+    <field name="rulename" type="osmatch">Interactive Shell Spawned from a Systemd Service [L0415B]</field>
+    <mitre>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="430350" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Curl/wget process spawned from a scheduled job [L0416].</description>
+    <field name="rulename" type="osmatch">Curl/wget process spawned from a scheduled job [L0416]</field>
+    <mitre>
+      <id>T1053.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="430360" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential SSH Hijacking [L0419].</description>
+    <field name="rulename" type="osmatch">Potential SSH Hijacking [L0419]</field>
+    <mitre>
+      <id>T1563.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="430370" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Masquerading as Parent Directory [L0420].</description>
+    <field name="rulename" type="osmatch">Process Masquerading as Parent Directory [L0420]</field>
+    <mitre>
+      <id>T1036.005</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430380" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Masquerading as Systemd Service [L0421].</description>
+    <field name="rulename" type="osmatch">Potential Masquerading as Systemd Service [L0421]</field>
+    <mitre>
+      <id>T1036.004</id>
+      <id>T1036.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="430390" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Root Shell Spawned from SSH [L0423].</description>
+    <field name="rulename" type="osmatch">Root Shell Spawned from SSH [L0423]</field>
+    <mitre>
+      <id>T1021.004</id>
+      <id>T1078.001</id>
+      <id>T1059.004</id>
+      <id>T1078.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="430400" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Masquerading - Space after Filename [L0424].</description>
+    <field name="rulename" type="osmatch">Potential Masquerading - Space after Filename [L0424]</field>
+    <mitre>
+      <id>T1036.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="430410" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious File Executed - Hidden [L0426A].</description>
+    <field name="rulename" type="osmatch">Suspicious File Executed - Hidden [L0426A]</field>
+    <mitre>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430420" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Dump Cached Credentials With Tdbdump [L0427].</description>
+    <field name="rulename" type="osmatch">Dump Cached Credentials With Tdbdump [L0427]</field>
+    <mitre>
+      <id>T1003.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="430430" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Service Stopped - Cron [L0428].</description>
+    <field name="rulename" type="osmatch">Service Stopped - Cron [L0428]</field>
+    <mitre>
+      <id>T1569</id>
+      <id>T1489</id>
+      <id>T1053.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="430440" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: HTTP/HTTPS connection made from a scheduled job [L0501].</description>
+    <field name="rulename" type="osmatch">HTTP/HTTPS connection made from a scheduled job [L0501]</field>
+    <mitre>
+      <id>T1071.001</id>
+      <id>T1102</id>
+    </mitre>
+  </rule>
+
+  <rule id="430450" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Network communication through port typical for TOR [L0502].</description>
+    <field name="rulename" type="osmatch">Network communication through port typical for TOR [L0502]</field>
+    <mitre>
+      <id>T1090.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="430460" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Raw Socket Created [L0503].</description>
+    <field name="rulename" type="osmatch">Raw Socket Created [L0503]</field>
+    <mitre>
+      <id>T1040</id>
+    </mitre>
+  </rule>
+
+  <rule id="430470" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Socket Filter Attached [L0504].</description>
+    <field name="rulename" type="osmatch">Socket Filter Attached [L0504]</field>
+    <mitre>
+      <id>T1040</id>
+      <id>T1205</id>
+    </mitre>
+  </rule>
+
+  <rule id="430480" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Data Exfiltration [L0505].</description>
+    <field name="rulename" type="osmatch">Potential Data Exfiltration [L0505]</field>
+    <mitre>
+      <id>T1020</id>
+      <id>T1041</id>
+      <id>T1567</id>
+    </mitre>
+  </rule>
+
+  <rule id="430490" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Lateral Movement via ssh [L0901A].</description>
+    <field name="rulename" type="osmatch">Potential Lateral Movement via ssh [L0901A]</field>
+    <mitre>
+      <id>T1021.004</id>
+      <id>T1059.004</id>
+      <id>T1105</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="430500" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Lateral Movement via ssh, curl / wget [L0901B].</description>
+    <field name="rulename" type="osmatch">Potential Lateral Movement via ssh, curl / wget [L0901B]</field>
+    <mitre>
+      <id>T1021.004</id>
+      <id>T1059.004</id>
+      <id>T1105</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="430510" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Lateral Movement via ssh, Pipe to Interpreter [L0901C].</description>
+    <field name="rulename" type="osmatch">Potential Lateral Movement via ssh, Pipe to Interpreter [L0901C]</field>
+    <mitre>
+      <id>T1021.004</id>
+      <id>T1059.004</id>
+      <id>T1059.006</id>
+      <id>T1105</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="430520" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User Login via SSH [L0902].</description>
+    <field name="rulename" type="osmatch">User Login via SSH [L0902]</field>
+    <mitre>
+      <id>T1021.004</id>
+      <id>T1078.001</id>
+      <id>T1078.002</id>
+      <id>T1078.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="430530" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User Login via SFTP/SCP [L0903].</description>
+    <field name="rulename" type="osmatch">User Login via SFTP/SCP [L0903]</field>
+    <mitre>
+      <id>T1021.004</id>
+      <id>T1059.004</id>
+      <id>T1078.001</id>
+      <id>T1078.002</id>
+      <id>T1078.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="430540" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Log Manipulation - Modified via Unusual Process [L1001A].</description>
+    <field name="rulename" type="osmatch">System Log Manipulation - Modified via Unusual Process [L1001A]</field>
+    <mitre>
+      <id>T1070.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="430550" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Log Manipulation - Cleared [L1001B].</description>
+    <field name="rulename" type="osmatch">System Log Manipulation - Cleared [L1001B]</field>
+    <mitre>
+      <id>T1070.002</id>
+      <id>T1070.004</id>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="430560" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User account-related files modified by an unusual process [L1002].</description>
+    <field name="rulename" type="osmatch">User account-related files modified by an unusual process [L1002]</field>
+    <mitre>
+      <id>T1136.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430570" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Modification of SSH authorized_keys [L1003].</description>
+    <field name="rulename" type="osmatch">Modification of SSH authorized_keys [L1003]</field>
+    <mitre>
+      <id>T1098.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="430580" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential timestomp attempt via touch [L1004].</description>
+    <field name="rulename" type="osmatch">Potential timestomp attempt via touch [L1004]</field>
+    <mitre>
+      <id>T1070.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="430590" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Shell History Manipulation - Modified via Unusual Process [L1005A].</description>
+    <field name="rulename" type="osmatch">Shell History Manipulation - Modified via Unusual Process [L1005A]</field>
+    <mitre>
+      <id>T1070.003</id>
+      <id>T1562.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="430600" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Shell History Manipulation - Cleared [L1005B].</description>
+    <field name="rulename" type="osmatch">Shell History Manipulation - Cleared [L1005B]</field>
+    <mitre>
+      <id>T1070.003</id>
+      <id>T1562.003</id>
+      <id>T1070.004</id>
+      <id>T1485</id>
+    </mitre>
+  </rule>
+
+  <rule id="430610" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Modification of sudoers File / Directory [L1006].</description>
+    <field name="rulename" type="osmatch">Modification of sudoers File / Directory [L1006]</field>
+    <mitre>
+      <id>T1548.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="430620" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User/group added/modified [L1007].</description>
+    <field name="rulename" type="osmatch">User/group added/modified [L1007]</field>
+    <mitre>
+      <id>T1136.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430630" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Modification of SSH server configuration [L1009A].</description>
+    <field name="rulename" type="osmatch">Modification of SSH server configuration [L1009A]</field>
+    <mitre>
+      <id>T1565.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430640" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Modification of SSH server configuration via sed [L1009B].</description>
+    <field name="rulename" type="osmatch">Modification of SSH server configuration via sed [L1009B]</field>
+    <mitre>
+      <id>T1565.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430650" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Modification of SSH server configuration via sed - specific parameters [L1009C].</description>
+    <field name="rulename" type="osmatch">Modification of SSH server configuration via sed - specific parameters [L1009C]</field>
+    <mitre>
+      <id>T1565.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430660" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Modification of &quot;hosts&quot; File [L1010].</description>
+    <field name="rulename" type="osmatch">Modification of &quot;hosts&quot; File [L1010]</field>
+    <mitre>
+      <id>T1565.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430670" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Modification of &quot;resolv.conf&quot; File [L1011].</description>
+    <field name="rulename" type="osmatch">Modification of &quot;resolv.conf&quot; File [L1011]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1565.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430680" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Firewall Manipulation - Rules Flushed / Deleted [L1012].</description>
+    <field name="rulename" type="osmatch">Firewall Manipulation - Rules Flushed / Deleted [L1012]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1565.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430690" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User Login via Console [L1015].</description>
+    <field name="rulename" type="osmatch">User Login via Console [L1015]</field>
+    <mitre>
+      <id>T1078.001</id>
+      <id>T1078.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="430700" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PAM Configuration Added/Modified [L1016].</description>
+    <field name="rulename" type="osmatch">PAM Configuration Added/Modified [L1016]</field>
+    <mitre>
+      <id>T1056.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430710" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential credentials discovery - read shell history, unusual process [L1101].</description>
+    <field name="rulename" type="osmatch">Potential credentials discovery - read shell history, unusual process [L1101]</field>
+    <mitre>
+      <id>T1552.001</id>
+      <id>T1552.003</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="430720" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential remote hosts discovery - read ssh/hosts files, unusual process [L1102].</description>
+    <field name="rulename" type="osmatch">Potential remote hosts discovery - read ssh/hosts files, unusual process [L1102]</field>
+    <mitre>
+      <id>T1018</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="430730" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User Account Files Read by an Unusual Process [L1103].</description>
+    <field name="rulename" type="osmatch">User Account Files Read by an Unusual Process [L1103]</field>
+    <mitre>
+      <id>T1087.001</id>
+      <id>T1003.008</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="430740" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Discovery commands executed by shell from a web server process [L1104].</description>
+    <field name="rulename" type="osmatch">Discovery commands executed by shell from a web server process [L1104]</field>
+    <mitre>
+      <id>T1059.004</id>
+      <id>T1033</id>
+      <id>T1082</id>
+      <id>T1083</id>
+    </mitre>
+  </rule>
+
+  <rule id="430750" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Querying IP Info [L1109].</description>
+    <field name="rulename" type="osmatch">Querying IP Info [L1109]</field>
+    <mitre>
+      <id>T1614</id>
+      <id>T1016.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430760" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Credentials Discovery - netrc, Unusual Process [L1115].</description>
+    <field name="rulename" type="osmatch">Potential Credentials Discovery - netrc, Unusual Process [L1115]</field>
+    <mitre>
+      <id>T1552.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430770" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Security Software Discovery [L1116].</description>
+    <field name="rulename" type="osmatch">Security Software Discovery [L1116]</field>
+    <mitre>
+      <id>T1057</id>
+      <id>T1518.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430780" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Environment Variables Read by an Unusual Process [L1117].</description>
+    <field name="rulename" type="osmatch">Process Environment Variables Read by an Unusual Process [L1117]</field>
+    <mitre>
+      <id>T1082</id>
+      <id>T1563.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="430790" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Firewall Manipulation - Disabled [L1201].</description>
+    <field name="rulename" type="osmatch">Firewall Manipulation - Disabled [L1201]</field>
+    <mitre>
+      <id>T1562.004</id>
+      <id>T1489</id>
+    </mitre>
+  </rule>
+
+  <rule id="430800" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Disabled SELinux via setenforce utility [L1202].</description>
+    <field name="rulename" type="osmatch">Disabled SELinux via setenforce utility [L1202]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1489</id>
+    </mitre>
+  </rule>
+
+  <rule id="430810" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Modification of SELinux configuration file [L1203].</description>
+    <field name="rulename" type="osmatch">Modification of SELinux configuration file [L1203]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430820" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Disabled AppArmor [L1204].</description>
+    <field name="rulename" type="osmatch">Disabled AppArmor [L1204]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1489</id>
+    </mitre>
+  </rule>
+
+  <rule id="430830" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Audit Configuration Modified [L1206].</description>
+    <field name="rulename" type="osmatch">Audit Configuration Modified [L1206]</field>
+    <mitre>
+      <id>T1562.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="430840" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Logging Configuration Modified [L1207].</description>
+    <field name="rulename" type="osmatch">Logging Configuration Modified [L1207]</field>
+    <mitre>
+      <id>T1562.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="430850" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Logging Disabled [L1208].</description>
+    <field name="rulename" type="osmatch">System Logging Disabled [L1208]</field>
+    <mitre>
+      <id>T1562.001</id>
+      <id>T1489</id>
+    </mitre>
+  </rule>
+
+  <rule id="430860" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Kernel Module Loaded from an Unusual Directory [L1301A].</description>
+    <field name="rulename" type="osmatch">Kernel Module Loaded from an Unusual Directory [L1301A]</field>
+    <mitre>
+      <id>T1547.006</id>
+      <id>T1014</id>
+    </mitre>
+  </rule>
+
+  <rule id="430870" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Kernel Module Loaded From an Unusual Directory - Specific [L1301B].</description>
+    <field name="rulename" type="osmatch">Kernel Module Loaded From an Unusual Directory - Specific [L1301B]</field>
+    <mitre>
+      <id>T1547.006</id>
+      <id>T1014</id>
+    </mitre>
+  </rule>
+
+  <rule id="430880" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Kernel Module Loaded via Unusual Method [L1302].</description>
+    <field name="rulename" type="osmatch">Kernel Module Loaded via Unusual Method [L1302]</field>
+    <mitre>
+      <id>T1547.006</id>
+      <id>T1014</id>
+    </mitre>
+  </rule>
+
+  <rule id="430890" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Launch Daemon Added / Modified [M0100A].</description>
+    <field name="rulename" type="osmatch">Launch Daemon Added / Modified [M0100A]</field>
+    <mitre>
+      <id>T1543.004</id>
+      <id>T1647</id>
+    </mitre>
+  </rule>
+
+  <rule id="430900" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Launch Daemon Added / Modified by a Suspicious Process [M0100B].</description>
+    <field name="rulename" type="osmatch">Launch Daemon Added / Modified by a Suspicious Process [M0100B]</field>
+    <mitre>
+      <id>T1543.004</id>
+      <id>T1647</id>
+    </mitre>
+  </rule>
+
+  <rule id="430910" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Launch Daemon Added / Modified via a Suspicious Ancestor [M0100C].</description>
+    <field name="rulename" type="osmatch">Launch Daemon Added / Modified via a Suspicious Ancestor [M0100C]</field>
+    <mitre>
+      <id>T1543.004</id>
+      <id>T1647</id>
+    </mitre>
+  </rule>
+
+  <rule id="430920" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Launch Agent Added / Modified [M0101A].</description>
+    <field name="rulename" type="osmatch">Launch Agent Added / Modified [M0101A]</field>
+    <mitre>
+      <id>T1543.001</id>
+      <id>T1647</id>
+    </mitre>
+  </rule>
+
+  <rule id="430930" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Launch Agent Added / Modified by a Suspicious Process [M0101B].</description>
+    <field name="rulename" type="osmatch">Launch Agent Added / Modified by a Suspicious Process [M0101B]</field>
+    <mitre>
+      <id>T1543.001</id>
+      <id>T1647</id>
+    </mitre>
+  </rule>
+
+  <rule id="430940" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Launch Agent Added / Modified via a Suspicious Ancestor [M0101C].</description>
+    <field name="rulename" type="osmatch">Launch Agent Added / Modified via a Suspicious Ancestor [M0101C]</field>
+    <mitre>
+      <id>T1543.001</id>
+      <id>T1647</id>
+    </mitre>
+  </rule>
+
+  <rule id="430950" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Modification of rc.common File [M0102].</description>
+    <field name="rulename" type="osmatch">Modification of rc.common File [M0102]</field>
+    <mitre>
+      <id>T1037.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="430960" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Emond Rule Added/Modified [M0105].</description>
+    <field name="rulename" type="osmatch">Emond Rule Added/Modified [M0105]</field>
+    <mitre>
+      <id>T1546.014</id>
+    </mitre>
+  </rule>
+
+  <rule id="430970" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Google Chrome profile modification by unpopular process [M0106].</description>
+    <field name="rulename" type="osmatch">Google Chrome profile modification by unpopular process [M0106]</field>
+    <mitre>
+      <id>T1176</id>
+      <id>T1185</id>
+    </mitre>
+  </rule>
+
+  <rule id="430980" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Association for Execution Changed [M0107].</description>
+    <field name="rulename" type="osmatch">File Association for Execution Changed [M0107]</field>
+    <mitre>
+      <id>T1546.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="430990" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Launch Daemon / Agent Added / Modified [M0108].</description>
+    <field name="rulename" type="osmatch">Suspicious Launch Daemon / Agent Added / Modified [M0108]</field>
+    <mitre>
+      <id>T1036.004</id>
+      <id>T1564.001</id>
+      <id>T1543.001</id>
+      <id>T1543.004</id>
+      <id>T1647</id>
+    </mitre>
+  </rule>
+
+  <rule id="431000" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Firewall Rules Manipulation [M0202].</description>
+    <field name="rulename" type="osmatch">Firewall Rules Manipulation [M0202]</field>
+    <mitre>
+      <id>T1562.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431010" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Write to a File with a Suspicious Extension [M0301].</description>
+    <field name="rulename" type="osmatch">Write to a File with a Suspicious Extension [M0301]</field>
+    <mitre>
+      <id>T1036.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="431020" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Set / Unset File Immutability via chflags [M0303].</description>
+    <field name="rulename" type="osmatch">Set / Unset File Immutability via chflags [M0303]</field>
+    <mitre>
+      <id>T1222.002</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431030" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Set File as Hidden [M0304].</description>
+    <field name="rulename" type="osmatch">Set File as Hidden [M0304]</field>
+    <mitre>
+      <id>T1564.001</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431040" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Process Deleted Origin File [M0306].</description>
+    <field name="rulename" type="osmatch">Suspicious Process Deleted Origin File [M0306]</field>
+    <mitre>
+      <id>T1070.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431050" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious File Dropped into Application Directory [M0307].</description>
+    <field name="rulename" type="osmatch">Suspicious File Dropped into Application Directory [M0307]</field>
+    <mitre>
+      <id>T1036.005</id>
+      <id>T1564.001</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="431060" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Application Executable Renamed [M0308].</description>
+    <field name="rulename" type="osmatch">Application Executable Renamed [M0308]</field>
+    <mitre>
+      <id>T1036.005</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431070" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious File Dropped to a Suspicious Location [M0309].</description>
+    <field name="rulename" type="osmatch">Suspicious File Dropped to a Suspicious Location [M0309]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431080" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Created via ditto in a Suspicious Directory [M0310].</description>
+    <field name="rulename" type="osmatch">Archive Created via ditto in a Suspicious Directory [M0310]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1074.001</id>
+      <id>T1119</id>
+    </mitre>
+  </rule>
+
+  <rule id="431090" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Archive Created by Utility in a Suspicious Directory [M0311].</description>
+    <field name="rulename" type="osmatch">Archive Created by Utility in a Suspicious Directory [M0311]</field>
+    <mitre>
+      <id>T1560.001</id>
+      <id>T1074.001</id>
+      <id>T1119</id>
+    </mitre>
+  </rule>
+
+  <rule id="431100" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious File Downloaded by a Web Browser [M0312].</description>
+    <field name="rulename" type="osmatch">Suspicious File Downloaded by a Web Browser [M0312]</field>
+    <mitre>
+      <id>T1204.001</id>
+      <id>T1204.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="431110" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Application Downloaded by a Web Browser [M0313].</description>
+    <field name="rulename" type="osmatch">Application Downloaded by a Web Browser [M0313]</field>
+    <mitre>
+      <id>T1566.003</id>
+      <id>T1204.001</id>
+      <id>T1204.002</id>
+      <id>T1105</id>
+      <id>T1071.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431120" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Application Similar to Known Malware Downloaded by a Web Browser [M0314].</description>
+    <field name="rulename" type="osmatch">Application Similar to Known Malware Downloaded by a Web Browser [M0314]</field>
+    <mitre>
+      <id>T1566.003</id>
+      <id>T1204.001</id>
+      <id>T1204.002</id>
+      <id>T1105</id>
+      <id>T1071.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431130" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Base64 Data Decoded via base64 Utility [M0403A].</description>
+    <field name="rulename" type="osmatch">Base64 Data Decoded via base64 Utility [M0403A]</field>
+    <mitre>
+      <id>T1140</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431140" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Base64 Data Decoded via Openssl Utility [M0403B].</description>
+    <field name="rulename" type="osmatch">Base64 Data Decoded via Openssl Utility [M0403B]</field>
+    <mitre>
+      <id>T1140</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431150" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Base64 Data Decoded via Python [M0403C].</description>
+    <field name="rulename" type="osmatch">Base64 Data Decoded via Python [M0403C]</field>
+    <mitre>
+      <id>T1140</id>
+      <id>T1132</id>
+      <id>T1059.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="431160" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Base64 Data Decoded via Perl [M0403D].</description>
+    <field name="rulename" type="osmatch">Base64 Data Decoded via Perl [M0403D]</field>
+    <mitre>
+      <id>T1140</id>
+      <id>T1132</id>
+      <id>T1059</id>
+    </mitre>
+  </rule>
+
+  <rule id="431170" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Openssl Decrypting Data [M0409].</description>
+    <field name="rulename" type="osmatch">Openssl Decrypting Data [M0409]</field>
+    <mitre>
+      <id>T1140</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431180" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Cron Job Added / Modified [M0410].</description>
+    <field name="rulename" type="osmatch">Cron Job Added / Modified [M0410]</field>
+    <mitre>
+      <id>T1053.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="431190" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: AppleScript Executed via Suspicious Ancestor [M0411].</description>
+    <field name="rulename" type="osmatch">AppleScript Executed via Suspicious Ancestor [M0411]</field>
+    <mitre>
+      <id>T1059.002</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431200" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File with a Suspicious Extension Executed [M0412].</description>
+    <field name="rulename" type="osmatch">File with a Suspicious Extension Executed [M0412]</field>
+    <mitre>
+      <id>T1036.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="431210" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Process Launched from a Mounted Volume [M0413].</description>
+    <field name="rulename" type="osmatch">Suspicious Process Launched from a Mounted Volume [M0413]</field>
+    <mitre>
+      <id>T1204.002</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431220" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Unsigned Application Launched from a Suspicious Directory [M0414].</description>
+    <field name="rulename" type="osmatch">Unsigned Application Launched from a Suspicious Directory [M0414]</field>
+    <mitre>
+      <id>T1204.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="431230" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Script Interpreter Launched by a Loaded Service [M0415].</description>
+    <field name="rulename" type="osmatch">Script Interpreter Launched by a Loaded Service [M0415]</field>
+    <mitre>
+      <id>T1059.002</id>
+      <id>T1059.004</id>
+      <id>T1059.006</id>
+      <id>T1569.001</id>
+      <id>T1543.004</id>
+      <id>T1543.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431240" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Self-Signed File Similar to Known Malware Executed [M0418].</description>
+    <field name="rulename" type="osmatch">Self-Signed File Similar to Known Malware Executed [M0418]</field>
+    <mitre>
+      <id>T1204.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="431250" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Process Masquerading [M0419].</description>
+    <field name="rulename" type="osmatch">Potential Process Masquerading [M0419]</field>
+    <mitre>
+      <id>T1036.005</id>
+      <id>T1204.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="431260" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Common Service Loaded via a Suspicious Ancestor [M0421].</description>
+    <field name="rulename" type="osmatch">Common Service Loaded via a Suspicious Ancestor [M0421]</field>
+    <mitre>
+      <id>T1036.004</id>
+      <id>T1569.001</id>
+      <id>T1543.004</id>
+      <id>T1543.001</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431270" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potentially Masqueraded Process Launched by a Loaded Service [M0422].</description>
+    <field name="rulename" type="osmatch">Potentially Masqueraded Process Launched by a Loaded Service [M0422]</field>
+    <mitre>
+      <id>T1036.004</id>
+      <id>T1569.001</id>
+      <id>T1543.004</id>
+      <id>T1543.001</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431280" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Process Launched by a Loaded Service [M0423].</description>
+    <field name="rulename" type="osmatch">Suspicious Process Launched by a Loaded Service [M0423]</field>
+    <mitre>
+      <id>T1569.001</id>
+      <id>T1543.004</id>
+      <id>T1543.001</id>
+      <id>T1564.001</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431290" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential Packet Capture by a Suspicious Process [M0500A].</description>
+    <field name="rulename" type="osmatch">Potential Packet Capture by a Suspicious Process [M0500A]</field>
+    <mitre>
+      <id>T1040</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431300" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Packet Capture by Utility via a Suspicious Ancestor [M0500B].</description>
+    <field name="rulename" type="osmatch">Packet Capture by Utility via a Suspicious Ancestor [M0500B]</field>
+    <mitre>
+      <id>T1040</id>
+      <id>T1005</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431310" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Filecoder Behavior [M0601].</description>
+    <field name="rulename" type="osmatch">Filecoder Behavior [M0601]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+  <rule id="431320" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Chrome Executing Suspicious Extension [M0701].</description>
+    <field name="rulename" type="osmatch">Chrome Executing Suspicious Extension [M0701]</field>
+    <mitre>
+      <id>T1176</id>
+    </mitre>
+  </rule>
+
+  <rule id="431330" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Web Browser Data Accessed by a Suspicious Process [M0702A].</description>
+    <field name="rulename" type="osmatch">Web Browser Data Accessed by a Suspicious Process [M0702A]</field>
+    <mitre>
+      <id>T1005</id>
+      <id>T1555.003</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431340" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Web Browser Data Accessed via a Suspicious Ancestor [M0702B].</description>
+    <field name="rulename" type="osmatch">Web Browser Data Accessed via a Suspicious Ancestor [M0702B]</field>
+    <mitre>
+      <id>T1005</id>
+      <id>T1555.003</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431350" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Turn on Remote Login [M0901].</description>
+    <field name="rulename" type="osmatch">Turn on Remote Login [M0901]</field>
+    <mitre>
+      <id>T1021.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431360" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Modification of &quot;sudoers&quot; File [M1002].</description>
+    <field name="rulename" type="osmatch">Modification of &quot;sudoers&quot; File [M1002]</field>
+    <mitre>
+      <id>T1548.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="431370" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Shell History Deleted [M1003].</description>
+    <field name="rulename" type="osmatch">Shell History Deleted [M1003]</field>
+    <mitre>
+      <id>T1070.003</id>
+      <id>T1070.004</id>
+      <id>T1562.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="431380" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Certificate Added into CERT ROOT [M1004].</description>
+    <field name="rulename" type="osmatch">Certificate Added into CERT ROOT [M1004]</field>
+    <mitre>
+      <id>T1553.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431390" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Modification of &quot;hosts&quot; File [M1005].</description>
+    <field name="rulename" type="osmatch">Modification of &quot;hosts&quot; File [M1005]</field>
+    <mitre>
+      <id>T1565.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431400" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Log Deleted by a Suspicious Process [M1007A].</description>
+    <field name="rulename" type="osmatch">System Log Deleted by a Suspicious Process [M1007A]</field>
+    <mitre>
+      <id>T1070.002</id>
+      <id>T1070.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431410" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Log Deleted via Utility [M1007B].</description>
+    <field name="rulename" type="osmatch">System Log Deleted via Utility [M1007B]</field>
+    <mitre>
+      <id>T1070.002</id>
+      <id>T1070.004</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431420" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Log Cleared [M1007C].</description>
+    <field name="rulename" type="osmatch">System Log Cleared [M1007C]</field>
+    <mitre>
+      <id>T1070.002</id>
+      <id>T1070.004</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431430" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Application Property List Modified by a Suspicious Process [M1009A].</description>
+    <field name="rulename" type="osmatch">Application Property List Modified by a Suspicious Process [M1009A]</field>
+    <mitre>
+      <id>T1647</id>
+    </mitre>
+  </rule>
+
+  <rule id="431440" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Application Property List Modified by Utility [M1009B].</description>
+    <field name="rulename" type="osmatch">Application Property List Modified by Utility [M1009B]</field>
+    <mitre>
+      <id>T1647</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431450" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible Credential Theft by Hash Dumping [M1101].</description>
+    <field name="rulename" type="osmatch">Possible Credential Theft by Hash Dumping [M1101]</field>
+    <mitre>
+      <id>T1003</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431460" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User Login Keychain Accessed by a Suspicious Process [M1106A].</description>
+    <field name="rulename" type="osmatch">User Login Keychain Accessed by a Suspicious Process [M1106A]</field>
+    <mitre>
+      <id>T1555.001</id>
+      <id>T1564.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431470" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User Login Keychain Accessed via a Suspicious Ancestor [M1106B].</description>
+    <field name="rulename" type="osmatch">User Login Keychain Accessed via a Suspicious Ancestor [M1106B]</field>
+    <mitre>
+      <id>T1555.001</id>
+      <id>T1564.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431480" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Private Keys / Credentials Accessed by a Suspicious Process [M1107A].</description>
+    <field name="rulename" type="osmatch">Private Keys / Credentials Accessed by a Suspicious Process [M1107A]</field>
+    <mitre>
+      <id>T1552.004</id>
+      <id>T1005</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431490" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Private Keys / Credentials Accessed via a Suspicious Ancestor [M1107B].</description>
+    <field name="rulename" type="osmatch">Private Keys / Credentials Accessed via a Suspicious Ancestor [M1107B]</field>
+    <mitre>
+      <id>T1552.004</id>
+      <id>T1005</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431500" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Log Accessed by a Suspicious Process [M1108A].</description>
+    <field name="rulename" type="osmatch">System Log Accessed by a Suspicious Process [M1108A]</field>
+    <mitre>
+      <id>T1654</id>
+      <id>T1005</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431510" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: System Log Accessed via a Suspicious Ancestor [M1108B].</description>
+    <field name="rulename" type="osmatch">System Log Accessed via a Suspicious Ancestor [M1108B]</field>
+    <mitre>
+      <id>T1654</id>
+      <id>T1005</id>
+      <id>T1564.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431520" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User Account Files Read by a Suspicious Process [M1110A].</description>
+    <field name="rulename" type="osmatch">User Account Files Read by a Suspicious Process [M1110A]</field>
+    <mitre>
+      <id>T1087.001</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431530" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: User Account Files Read by an Unusual Process [M1110B].</description>
+    <field name="rulename" type="osmatch">User Account Files Read by an Unusual Process [M1110B]</field>
+    <mitre>
+      <id>T1087.001</id>
+      <id>T1005</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431540" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Keychain Access via security Utility [M1111].</description>
+    <field name="rulename" type="osmatch">Suspicious Keychain Access via security Utility [M1111]</field>
+    <mitre>
+      <id>T1555.001</id>
+      <id>T1005</id>
+      <id>T1059.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="431550" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible Password Manager Database Access [M1112].</description>
+    <field name="rulename" type="osmatch">Possible Password Manager Database Access [M1112]</field>
+    <mitre>
+      <id>T1555.005</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431560" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Manipulate with the Security EventLog service registry key [N0201].</description>
+    <field name="rulename" type="osmatch">Manipulate with the Security EventLog service registry key [N0201]</field>
+    <mitre>
+      <id>T1562.002</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="431570" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Reading Sensitive Files - Google Chrome Browser [N0701].</description>
+    <field name="rulename" type="osmatch">Process Reading Sensitive Files - Google Chrome Browser [N0701]</field>
+    <mitre>
+      <id>T1555.003</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431580" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Reading Sensitive Files - Safari Browser [N0702].</description>
+    <field name="rulename" type="osmatch">Process Reading Sensitive Files - Safari Browser [N0702]</field>
+    <mitre>
+      <id>T1555.003</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431590" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Reading Sensitive Files - Mozilla Firefox Browser [N0703].</description>
+    <field name="rulename" type="osmatch">Process Reading Sensitive Files - Mozilla Firefox Browser [N0703]</field>
+    <mitre>
+      <id>T1555.003</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431600" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Reading Sensitive Files - Opera Browser [N0704].</description>
+    <field name="rulename" type="osmatch">Process Reading Sensitive Files - Opera Browser [N0704]</field>
+    <mitre>
+      <id>T1555.003</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431610" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Reading Sensitive Files - Vivaldi Browser [N0705].</description>
+    <field name="rulename" type="osmatch">Process Reading Sensitive Files - Vivaldi Browser [N0705]</field>
+    <mitre>
+      <id>T1555.003</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431620" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Reading Sensitive Files - Microsoft Edge Browser [N0706].</description>
+    <field name="rulename" type="osmatch">Process Reading Sensitive Files - Microsoft Edge Browser [N0706]</field>
+    <mitre>
+      <id>T1555.003</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431630" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Reading Sensitive Files - Brave Browser [N0707].</description>
+    <field name="rulename" type="osmatch">Process Reading Sensitive Files - Brave Browser [N0707]</field>
+    <mitre>
+      <id>T1555.003</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431640" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Reading Sensitive Files - Avast Secure Browser [N0708].</description>
+    <field name="rulename" type="osmatch">Process Reading Sensitive Files - Avast Secure Browser [N0708]</field>
+    <mitre>
+      <id>T1555.003</id>
+      <id>T1005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431650" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential event log clearing by loading wevtapi dll utility [N1002].</description>
+    <field name="rulename" type="osmatch">Potential event log clearing by loading wevtapi dll utility [N1002]</field>
+    <mitre>
+      <id>T1070.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431660" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Clearing event logs by powershell [N1003].</description>
+    <field name="rulename" type="osmatch">Clearing event logs by powershell [N1003]</field>
+    <mitre>
+      <id>T1070.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431670" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Clearing event logs by powershell script [N1004].</description>
+    <field name="rulename" type="osmatch">Clearing event logs by powershell script [N1004]</field>
+    <mitre>
+      <id>T1070.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431680" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Disable EventLog service using sc.exe [N1005].</description>
+    <field name="rulename" type="osmatch">Disable EventLog service using sc.exe [N1005]</field>
+    <mitre>
+      <id>T1562.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="431690" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Potential reverse shell [P0401].</description>
+    <field name="rulename" type="osmatch">Potential reverse shell [P0401]</field>
+    <mitre>
+      <id>T1059.004</id>
+      <id>T1059.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="431700" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Renamed MEGA Executed [P0403].</description>
+    <field name="rulename" type="osmatch">Renamed MEGA Executed [P0403]</field>
+    <mitre>
+      <id>T1036</id>
+    </mitre>
+  </rule>
+
+  <rule id="431710" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: MEGA Folder Synchronized [P0501].</description>
+    <field name="rulename" type="osmatch">MEGA Folder Synchronized [P0501]</field>
+    <mitre>
+      <id>T1567.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="431720" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: MEGA Cloud Storage Accessed [P0502].</description>
+    <field name="rulename" type="osmatch">MEGA Cloud Storage Accessed [P0502]</field>
+    <mitre>
+      <id>T1567.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="431730" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Synchronized from MEGA [P0503].</description>
+    <field name="rulename" type="osmatch">File Synchronized from MEGA [P0503]</field>
+    <mitre>
+      <id>T1102</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="431740" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Service Installed - Possibly Embargo Ransomware [Q0101].</description>
+    <field name="rulename" type="osmatch">Suspicious Service Installed - Possibly Embargo Ransomware [Q0101]</field>
+    <mitre>
+      <id>T1543.003</id>
+      <id>T1569.002</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="431750" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Scheduled Task Created - Possibly Embargo Ransomware [Q0103].</description>
+    <field name="rulename" type="osmatch">Suspicious Scheduled Task Created - Possibly Embargo Ransomware [Q0103]</field>
+    <mitre>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431760" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Killer Ultra Scheduled Task Persistence [Q0104].</description>
+    <field name="rulename" type="osmatch">Killer Ultra Scheduled Task Persistence [Q0104]</field>
+    <mitre>
+      <id>T1053.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="431770" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Killer Ultra Persistence Service [Q0105].</description>
+    <field name="rulename" type="osmatch">Killer Ultra Persistence Service [Q0105]</field>
+    <mitre>
+      <id>T1543.002</id>
+      <id>T1569.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="431780" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Killer Ultra Persistence Service Registry [Q0106].</description>
+    <field name="rulename" type="osmatch">Killer Ultra Persistence Service Registry [Q0106]</field>
+    <mitre>
+      <id>T1543.003</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="431790" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: File Sent To Remote Location [Q0302].</description>
+    <field name="rulename" type="osmatch">File Sent To Remote Location [Q0302]</field>
+    <mitre>
+      <id>T1074.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="431800" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious File Dropped Into Windows Debug Path [Q0303].</description>
+    <field name="rulename" type="osmatch">Suspicious File Dropped Into Windows Debug Path [Q0303]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="431810" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Host Process for Windows Tasks Dropped a Suspicious Executable [Q0305].</description>
+    <field name="rulename" type="osmatch">Host Process for Windows Tasks Dropped a Suspicious Executable [Q0305]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="431820" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Command Shell Dropped a Suspicious Executable [Q0306].</description>
+    <field name="rulename" type="osmatch">Windows Command Shell Dropped a Suspicious Executable [Q0306]</field>
+    <mitre>
+      <id>T1059.003</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="431830" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Kernel Dropped a Suspicious Executable [Q0307].</description>
+    <field name="rulename" type="osmatch">Windows Kernel Dropped a Suspicious Executable [Q0307]</field>
+    <mitre>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="431840" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible EDR Blinding - Rename Files [Q0308].</description>
+    <field name="rulename" type="osmatch">Possible EDR Blinding - Rename Files [Q0308]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431850" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Killer Ultra Exec File Written [Q0309].</description>
+    <field name="rulename" type="osmatch">Suspicious Killer Ultra Exec File Written [Q0309]</field>
+    <mitre>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="431860" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: EDRSilencer Dropped [Q0310].</description>
+    <field name="rulename" type="osmatch">EDRSilencer Dropped [Q0310]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431870" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Edge Dropped a Suspicious Executable [Q0312].</description>
+    <field name="rulename" type="osmatch">Edge Dropped a Suspicious Executable [Q0312]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1189</id>
+    </mitre>
+  </rule>
+
+  <rule id="431880" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Saving Script File From Office Suite [Q0313].</description>
+    <field name="rulename" type="osmatch">Saving Script File From Office Suite [Q0313]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="431890" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: EDRKillShifter Dropped [Q0314].</description>
+    <field name="rulename" type="osmatch">EDRKillShifter Dropped [Q0314]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431900" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Vulnerable Windows Component Dropped [Q0315].</description>
+    <field name="rulename" type="osmatch">Vulnerable Windows Component Dropped [Q0315]</field>
+    <mitre>
+      <id>T1562.010</id>
+    </mitre>
+  </rule>
+
+  <rule id="431910" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Elevated PowerShell Executed [Q0407].</description>
+    <field name="rulename" type="osmatch">Elevated PowerShell Executed [Q0407]</field>
+    <mitre>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431920" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Edge Executed a Suspicious Executable [Q0411].</description>
+    <field name="rulename" type="osmatch">Edge Executed a Suspicious Executable [Q0411]</field>
+    <mitre>
+      <id>T1105</id>
+      <id>T1189</id>
+      <id>T1204.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431930" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious Killer Ultra Executables Run [Q0415].</description>
+    <field name="rulename" type="osmatch">Suspicious Killer Ultra Executables Run [Q0415]</field>
+    <mitre>
+      <id>T1106</id>
+    </mitre>
+  </rule>
+
+  <rule id="431940" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Vulnerable Veeam Backup Service Spawns Cmd/PowerShell [Q0416].</description>
+    <field name="rulename" type="osmatch">Vulnerable Veeam Backup Service Spawns Cmd/PowerShell [Q0416]</field>
+    <mitre>
+      <id>T1203</id>
+      <id>T1068</id>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="431950" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Vulnerable Veeam Backup Database Credential Dump [Q0417].</description>
+    <field name="rulename" type="osmatch">Vulnerable Veeam Backup Database Credential Dump [Q0417]</field>
+    <mitre>
+      <id>T1203</id>
+      <id>T1005</id>
+      <id>T1212</id>
+    </mitre>
+  </rule>
+
+  <rule id="431960" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Vulnerable Veeam Backup - Suspicious Database Query [Q0418].</description>
+    <field name="rulename" type="osmatch">Vulnerable Veeam Backup - Suspicious Database Query [Q0418]</field>
+    <mitre>
+      <id>T1203</id>
+      <id>T1005</id>
+      <id>T1212</id>
+    </mitre>
+  </rule>
+
+  <rule id="431970" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Vulnerable Veeam Backup - Discovery Command [Q0419].</description>
+    <field name="rulename" type="osmatch">Vulnerable Veeam Backup - Discovery Command [Q0419]</field>
+    <mitre>
+      <id>T1203</id>
+      <id>T1087</id>
+      <id>T1057</id>
+    </mitre>
+  </rule>
+
+  <rule id="431980" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious EDRKillShifter Executable [Q0420].</description>
+    <field name="rulename" type="osmatch">Suspicious EDRKillShifter Executable [Q0420]</field>
+    <mitre>
+      <id>T1562.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="431990" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible DCOM Upload &amp; Execute Attack [Q0421].</description>
+    <field name="rulename" type="osmatch">Possible DCOM Upload &amp; Execute Attack [Q0421]</field>
+    <mitre>
+      <id>T1021.003</id>
+      <id>T1570</id>
+    </mitre>
+  </rule>
+
+  <rule id="432000" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible Cleo Software Exploitation [Q0422].</description>
+    <field name="rulename" type="osmatch">Possible Cleo Software Exploitation [Q0422]</field>
+    <mitre>
+      <id>T1190</id>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1027.010</id>
+    </mitre>
+  </rule>
+
+  <rule id="432010" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process Connecting To Ngrok-Managed Domain [Q0501].</description>
+    <field name="rulename" type="osmatch">Process Connecting To Ngrok-Managed Domain [Q0501]</field>
+    <mitre>
+      <id>T1572</id>
+    </mitre>
+  </rule>
+
+  <rule id="432020" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - AeroAdmin [Q0902].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - AeroAdmin [Q0902]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432030" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - AnyViewer [Q0903].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - AnyViewer [Q0903]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432040" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - ChromeRDP - Networking [Q0904].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - ChromeRDP - Networking [Q0904]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432050" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - DesktopNow [Q0905].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - DesktopNow [Q0905]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432060" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - DistantDesktop [Q0906].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - DistantDesktop [Q0906]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432070" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - RAdmin [Q0907].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - RAdmin [Q0907]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432080" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - RustDesk [Q0909].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - RustDesk [Q0909]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432090" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - ShowMyPC [Q0910].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - ShowMyPC [Q0910]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432100" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - SimpleHelp [Q0911].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - SimpleHelp [Q0911]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432110" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - UltraViewer [Q0914].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - UltraViewer [Q0914]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432120" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - DWservice [Q0916].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - DWservice [Q0916]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432130" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - MeshCentral Agent [Q0917].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - MeshCentral Agent [Q0917]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432140" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - mRemoteNG [Q0918].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - mRemoteNG [Q0918]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432150" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - ChromeRDP - Host [Q0919].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - ChromeRDP - Host [Q0919]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432160" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wmiexec Remote Shell Command Executed [Q0920].</description>
+    <field name="rulename" type="osmatch">Wmiexec Remote Shell Command Executed [Q0920]</field>
+    <mitre>
+      <id>T1021</id>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="432170" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Wmiexec Suspicious Remote Execution [Q0921].</description>
+    <field name="rulename" type="osmatch">Wmiexec Suspicious Remote Execution [Q0921]</field>
+    <mitre>
+      <id>T1021</id>
+      <id>T1047</id>
+    </mitre>
+  </rule>
+
+  <rule id="432180" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI Provider Executing Command or Scripting Interpreter [Q0922].</description>
+    <field name="rulename" type="osmatch">WMI Provider Executing Command or Scripting Interpreter [Q0922]</field>
+    <mitre>
+      <id>T1021</id>
+      <id>T1047</id>
+      <id>T1059</id>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1218</id>
+      <id>T1218.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="432190" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI Provider Executing Discovery Tool [Q0923].</description>
+    <field name="rulename" type="osmatch">WMI Provider Executing Discovery Tool [Q0923]</field>
+    <mitre>
+      <id>T1021</id>
+      <id>T1047</id>
+      <id>T1007</id>
+      <id>T1010</id>
+      <id>T1016</id>
+      <id>T1018</id>
+      <id>T1033</id>
+      <id>T1049</id>
+      <id>T1057</id>
+      <id>T1082</id>
+      <id>T1083</id>
+      <id>T1087.001</id>
+      <id>T1087.002</id>
+      <id>T1120</id>
+      <id>T1482</id>
+      <id>T1518</id>
+      <id>T1518.001</id>
+      <id>T1558</id>
+      <id>T1652</id>
+    </mitre>
+  </rule>
+
+  <rule id="432200" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI Provider Executing LOLBin [Q0924].</description>
+    <field name="rulename" type="osmatch">WMI Provider Executing LOLBin [Q0924]</field>
+    <mitre>
+      <id>T1021</id>
+      <id>T1047</id>
+      <id>T1218</id>
+      <id>T1218.001</id>
+      <id>T1218.002</id>
+      <id>T1218.003</id>
+      <id>T1218.004</id>
+      <id>T1218.007</id>
+      <id>T1218.008</id>
+      <id>T1218.009</id>
+      <id>T1218.010</id>
+      <id>T1218.011</id>
+      <id>T1218.012</id>
+      <id>T1218.013</id>
+      <id>T1218.014</id>
+      <id>T1218.015</id>
+      <id>T1222.001</id>
+      <id>T1127.001</id>
+      <id>T1216.001</id>
+      <id>T1216.002</id>
+      <id>T1105</id>
+      <id>T1053.002</id>
+    </mitre>
+  </rule>
+
+  <rule id="432210" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - Atera [Q0925].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - Atera [Q0925]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432220" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Smbexec Silent Command Execution [Q0926].</description>
+    <field name="rulename" type="osmatch">Smbexec Silent Command Execution [Q0926]</field>
+    <mitre>
+      <id>T1569.002</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="432230" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Registry Service Start Modification - Potential Credential Dump [Q0927].</description>
+    <field name="rulename" type="osmatch">Remote Registry Service Start Modification - Potential Credential Dump [Q0927]</field>
+    <mitre>
+      <id>T1112</id>
+      <id>T1003</id>
+      <id>T1003.001</id>
+      <id>T1003.002</id>
+      <id>T1003.003</id>
+      <id>T1003.004</id>
+      <id>T1003.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="432240" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Smbexec Silent PowerShell Execution [Q0928].</description>
+    <field name="rulename" type="osmatch">Smbexec Silent PowerShell Execution [Q0928]</field>
+    <mitre>
+      <id>T1569.002</id>
+      <id>T1059.003</id>
+      <id>T1059.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="432250" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Smbexec Silent Discovery Tool Execution [Q0929].</description>
+    <field name="rulename" type="osmatch">Smbexec Silent Discovery Tool Execution [Q0929]</field>
+    <mitre>
+      <id>T1569.002</id>
+      <id>T1059.003</id>
+      <id>T1007</id>
+      <id>T1010</id>
+      <id>T1016</id>
+      <id>T1018</id>
+      <id>T1033</id>
+      <id>T1049</id>
+      <id>T1057</id>
+      <id>T1082</id>
+      <id>T1083</id>
+      <id>T1087.001</id>
+      <id>T1087.002</id>
+      <id>T1120</id>
+      <id>T1482</id>
+      <id>T1518</id>
+      <id>T1518.001</id>
+      <id>T1558</id>
+      <id>T1652</id>
+    </mitre>
+  </rule>
+
+  <rule id="432260" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Netexec Wmiexec Remote Execution [Q0930].</description>
+    <field name="rulename" type="osmatch">Netexec Wmiexec Remote Execution [Q0930]</field>
+    <mitre>
+      <id>T1021</id>
+      <id>T1021.002</id>
+      <id>T1047</id>
+      <id>T1059</id>
+      <id>T1059.003</id>
+      <id>T1569.002</id>
+      <id>T1140</id>
+      <id>T1112</id>
+    </mitre>
+  </rule>
+
+  <rule id="432270" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Smbexec Remote Execution [Q0931].</description>
+    <field name="rulename" type="osmatch">Smbexec Remote Execution [Q0931]</field>
+    <mitre>
+      <id>T1021.002</id>
+      <id>T1569.002</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="432280" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Windows Event Logs Clearing [Q1001].</description>
+    <field name="rulename" type="osmatch">Windows Event Logs Clearing [Q1001]</field>
+    <mitre>
+      <id>T1070.001</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="432290" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Query Registry For Passwords [Q1101].</description>
+    <field name="rulename" type="osmatch">Query Registry For Passwords [Q1101]</field>
+    <mitre>
+      <id>T1552.002</id>
+      <id>T1012</id>
+    </mitre>
+  </rule>
+
+  <rule id="432300" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: List Stored Credentials With Cmdkey [Q1102].</description>
+    <field name="rulename" type="osmatch">List Stored Credentials With Cmdkey [Q1102]</field>
+    <mitre>
+      <id>T1003.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="432310" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Event Tracing for Windows (ETW) Tampering [Q1202].</description>
+    <field name="rulename" type="osmatch">Event Tracing for Windows (ETW) Tampering [Q1202]</field>
+    <mitre>
+      <id>T1562.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="432320" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Event Tracing for Windows (ETW) Tampering [Q1204].</description>
+    <field name="rulename" type="osmatch">Event Tracing for Windows (ETW) Tampering [Q1204]</field>
+    <mitre>
+      <id>T1562.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="432330" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Possible EDR Blinding - Vulnerable Driver [Q1301].</description>
+    <field name="rulename" type="osmatch">Possible EDR Blinding - Vulnerable Driver [Q1301]</field>
+    <mitre>
+      <id>T1068</id>
+    </mitre>
+  </rule>
+
+  <rule id="432340" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Vulnerable Driver Masquerading [Q1302].</description>
+    <field name="rulename" type="osmatch">Vulnerable Driver Masquerading [Q1302]</field>
+    <mitre>
+      <id>T1068</id>
+      <id>T1211</id>
+      <id>T1036</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="432350" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Vulnerable Zemana Driver Loaded [Q1303].</description>
+    <field name="rulename" type="osmatch">Vulnerable Zemana Driver Loaded [Q1303]</field>
+    <mitre>
+      <id>T1068</id>
+      <id>T1211</id>
+    </mitre>
+  </rule>
+
+  <rule id="432360" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Vulnerable Zemana Driver Dropped [Q1304].</description>
+    <field name="rulename" type="osmatch">Vulnerable Zemana Driver Dropped [Q1304]</field>
+    <mitre>
+      <id>T1068</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="432370" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious MS SQL (sqlservr.exe) cmd /c Child Process [R0401].</description>
+    <field name="rulename" type="osmatch">Suspicious MS SQL (sqlservr.exe) cmd /c Child Process [R0401]</field>
+    <mitre>
+      <id>T1505.001</id>
+      <id>T1190</id>
+    </mitre>
+  </rule>
+
+  <rule id="432380" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious MS SQL (sqlservr.exe) Child Process [R0402].</description>
+    <field name="rulename" type="osmatch">Suspicious MS SQL (sqlservr.exe) Child Process [R0402]</field>
+    <mitre>
+      <id>T1505.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="432390" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: MS SQL (sqlservr.exe) Executed Process via WMI [R0403].</description>
+    <field name="rulename" type="osmatch">MS SQL (sqlservr.exe) Executed Process via WMI [R0403]</field>
+    <mitre>
+      <id>T1047</id>
+      <id>T1059.005</id>
+      <id>T1505.001</id>
+    </mitre>
+  </rule>
+
+  <rule id="432400" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: sqlservr.exe Drops Suspicious Module [R0404].</description>
+    <field name="rulename" type="osmatch">sqlservr.exe Drops Suspicious Module [R0404]</field>
+    <mitre>
+      <id>T1505.001</id>
+      <id>T1105</id>
+    </mitre>
+  </rule>
+
+  <rule id="432410" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Suspicious msiexec.exe Execution by a Service [R0405].</description>
+    <field name="rulename" type="osmatch">Suspicious msiexec.exe Execution by a Service [R0405]</field>
+    <mitre>
+      <id>T1505.001</id>
+      <id>T1505.003</id>
+      <id>T1505.004</id>
+    </mitre>
+  </rule>
+
+  <rule id="432420" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: SQLRecon.exe Suspicious Activity [R0407].</description>
+    <field name="rulename" type="osmatch">SQLRecon.exe Suspicious Activity [R0407]</field>
+    <mitre>
+      <id>T1505.001</id>
+      <id>T1059.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="432430" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI Event Scheduler Subscription (ASEC) Suspicious Remote Execution [R0901].</description>
+    <field name="rulename" type="osmatch">WMI Event Scheduler Subscription (ASEC) Suspicious Remote Execution [R0901]</field>
+    <mitre>
+      <id>T1021</id>
+      <id>T1047</id>
+      <id>T1546.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="432440" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI Event Subscription (ASEC) Command Execution [R0902].</description>
+    <field name="rulename" type="osmatch">WMI Event Subscription (ASEC) Command Execution [R0902]</field>
+    <mitre>
+      <id>T1021</id>
+      <id>T1047</id>
+      <id>T1546.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="432450" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI Event Scheduler Suspicious Remote Execution [R0903].</description>
+    <field name="rulename" type="osmatch">WMI Event Scheduler Suspicious Remote Execution [R0903]</field>
+    <mitre>
+      <id>T1053.005</id>
+      <id>T1059.003</id>
+      <id>T1021</id>
+      <id>T1047</id>
+      <id>T1546.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="432460" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WMI Event Subscription (ASEC) Command Output [R0904].</description>
+    <field name="rulename" type="osmatch">WMI Event Subscription (ASEC) Command Output [R0904]</field>
+    <mitre>
+      <id>T1021</id>
+      <id>T1047</id>
+      <id>T1546.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="432470" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - RustDesk Install From .exe Package [R0905].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - RustDesk Install From .exe Package [R0905]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432480" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - ScreenConnect Install From .exe Package [R0906].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - ScreenConnect Install From .exe Package [R0906]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432490" level="8">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - ScreenConnect Ran a Command [R0907].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - ScreenConnect Ran a Command [R0907]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432500" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - ScreenConnect Install From .msi Package [R0908].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - ScreenConnect Install From .msi Package [R0908]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432510" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Remote Monitoring &amp; Management - RustDesk Install From .msi Package [R0909].</description>
+    <field name="rulename" type="osmatch">Remote Monitoring &amp; Management - RustDesk Install From .msi Package [R0909]</field>
+    <mitre>
+      <id>T1219</id>
+    </mitre>
+  </rule>
+
+  <rule id="432520" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WinRM Outbound Connection [R0910].</description>
+    <field name="rulename" type="osmatch">WinRM Outbound Connection [R0910]</field>
+    <mitre>
+      <id>T1021.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="432530" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WinRM Inbound Connection [R0911].</description>
+    <field name="rulename" type="osmatch">WinRM Inbound Connection [R0911]</field>
+    <mitre>
+      <id>T1021.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="432540" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: WinRM Execution Identified via CreateNamedPipe [R0912] .</description>
+    <field name="rulename" type="osmatch">WinRM Execution Identified via CreateNamedPipe [R0912]</field>
+    <mitre>
+      <id>T1021.006</id>
+    </mitre>
+  </rule>
+
+  <rule id="432550" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: PowerShell from Startup Shortcut Decrypts and Loads Assembly [V0100].</description>
+    <field name="rulename" type="osmatch">PowerShell from Startup Shortcut Decrypts and Loads Assembly [V0100]</field>
+    <mitre>
+      <id>T1547.001</id>
+      <id>T1547.009</id>
+      <id>T1620</id>
+      <id>T1140</id>
+    </mitre>
+  </rule>
+
+  <rule id="432560" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: TorBrowser-like Command-line [V0501].</description>
+    <field name="rulename" type="osmatch">TorBrowser-like Command-line [V0501]</field>
+    <mitre>
+      <id>T1573.002</id>
+      <id>T1090.003</id>
+    </mitre>
+  </rule>
+
+  <rule id="432570" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Saving script file [Z0301].</description>
+    <field name="rulename" type="osmatch">Saving script file [Z0301]</field>
+    <mitre>
+      <id>T1059.001</id>
+      <id>T1059.003</id>
+      <id>T1059.005</id>
+      <id>T1059.007</id>
+    </mitre>
+  </rule>
+
+  <rule id="432580" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Non-System process with system process name has started [Z0400].</description>
+    <field name="rulename" type="osmatch">Non-System process with system process name has started [Z0400]</field>
+    <mitre>
+      <id>T1036.005</id>
+    </mitre>
+  </rule>
+
+  <rule id="432590" level="4">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Process has started from a removable drive [Z0401].</description>
+    <field name="rulename" type="osmatch">Process has started from a removable drive [Z0401]</field>
+    <mitre>
+      <id>T1091</id>
+    </mitre>
+  </rule>
+
+  <rule id="432600" level="13">
+    <if_sid>440050</if_sid>
+    <description>ESET EDR rule: Filecoder behavior [Z0601].</description>
+    <field name="rulename" type="osmatch">Filecoder behavior [Z0601]</field>
+    <mitre>
+      <id>T1486</id>
+    </mitre>
+  </rule>
+
+</group>


### PR DESCRIPTION
## Summary

- Adds decoder and rules for ingesting **ESET Protect On-Premise** syslog JSON output directly, without requiring the Cloud API integration script
- Custom decoder handles RFC 5424 syslog from ESET Protect On-Prem
- 1,263 rules covering all 7 ESET event types with severity escalation and MITRE ATT&CK mappings

## Background

The existing `eset_local_rules.xml` is designed for the ESET Cloud API integration script, which wraps events in a custom JSON structure with fields like `eset.category`, `eset.severityLevel`, and `eset.edrRuleUuid`.

ESET Protect On-Premise has a built-in **Syslog export** feature that sends events directly over syslog in RFC 5424 format with a JSON payload. The JSON schema differs from the API output — it uses root-level fields like `event_type`, `severity`, `threat_name`, etc. as documented at:
https://help.eset.com/protect_admin/12.1/en-US/events-exported-to-json-format.html

This PR adds native Wazuh support for these syslog events, enabling ESET Protect On-Prem users to get full detection coverage without running the Cloud API integration.

## Files added

| File | Description |
|------|-------------|
| `eset_syslog_decoder.xml` | Custom decoder for RFC 5424 syslog from ESET Protect On-Prem |
| `eset_syslog_rules.xml` | 1,263 rules: 16 base/category/severity rules + 1,247 EDR rules |
| `README_syslog.md` | Setup and configuration documentation |

## Rule coverage

- **7 event types**: Threat_Event, FirewallAggregated_Event, HipsAggregated_Event, EnterpriseInspectorAlert_Event, BlockedFiles_Event, Audit_Event, FilteredWebsites_Event
- **Severity escalation**: Warning (level 7), Critical (level 12), Fatal (level 15)
- **1,247 EDR rules** mapped from existing `eset_local_rules.xml` using the `rulename` field, with original rule IDs and MITRE ATT&CK technique IDs preserved